### PR TITLE
Ignore key + lean query support.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ var util = require('util')
   
 var dbg = false;  
   
-var parseQuery = function(query){
+var parseQuery = function(query, options){
   /**
   
   reserved keys: q,t,f,s,sk,l,p
@@ -203,7 +203,9 @@ var parseQuery = function(query){
         } else if(operator == 'c') {
           val = val.split('/');
           addCondition(lcKey, new RegExp(val[0], val[1]));
-        } else if (key != 'apikey') {
+        } else {
+          if (options.ignoreKeys === true) return;
+          if (options.ignoreKeys && typeof options.ignoreKeys.indexOf === 'function' && options.ignoreKeys.indexOf(key) != -1) return;
           var parts = val.split('|');
           if( parts.length > 1){
             var arr = []
@@ -260,10 +262,10 @@ var parseQuery = function(query){
   }
   return qy;
 }
-var doQuery = function(query, model, lean, callback)
+var doQuery = function(query, model, options, callback)
 {
   if(dbg)console.log(query);
-  var q = parseQuery(query);
+  var q = parseQuery(query, options);
   if(!model)return q;
   if(dbg)console.log(q);
   var find = model;
@@ -314,7 +316,7 @@ var doQuery = function(query, model, lean, callback)
     if(q.f) find = find.select(q.f);
     if(q.p) find = find.populate(q.p);
 
-    if (lean) find = find.lean();
+    if (options.lean) find = find.lean();
     
     if( q.t === 'findOne' ){
       if( q.fl ) {
@@ -348,9 +350,13 @@ var doQuery = function(query, model, lean, callback)
 
 module.exports = exports = function QueryPlugin(schema, options) {
   schema.statics.query = schema.statics.Query = function(query, callback){
-    doQuery(query, this, false, callback)
+    options = options || {};
+    options.lean = false;
+    doQuery(query, this, options, callback)
   }
   schema.statics.leanQuery = schema.statics.leanQuery = function(query, callback){
-    doQuery(query, this, true, callback)
+    options = options || {};
+    options.lean = true;
+    doQuery(query, this, options, callback)
   }
 }


### PR DESCRIPTION
Hello,

My name is Gabor, and I want to contribute my ideas to library of yours. I'm from a .NET background, and I'm still a huge fan of the OData protocol. I think your project eventually will catch it regarding the query possibilities in a way that fits best in the MongoDb world.

I have a small pull request right now. Two issues addressed:
- If you use Passport LocalApiKey module, then you have to send "apikey" parameter in the query string. But  the current implementation will add this to the query. I added support for handling the mongoose plugin options object, so on schema plugin definition it is possible to ignore query keys, for ex:

contentSchema.plugin(QueryPlugin, { ignoreKeys: "apikey" }); // will ignore ?...&apikey=blahblah
contentSchema.plugin(QueryPlugin, { ignoreKeys: true }); // will ignore all query keys which is not q,t,f,s,etc
- When someone use mongoose-query there won't be serverside operations on the result often. Istead the result will be pushed toward the clients immediately. So for performance reasons there should be no mongoose magic, just plain old json objects. For this purpose I've added an other plugn operation, leanQuery.

p.s.: I'm thinking other query methods, like defineQuery which is not executes the query just definie it. This way we can easily intergate mongoose-query with mongoose-q.
