### PR TITLE
Support populate options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -251,7 +251,13 @@ var parseQuery = function(query, options){
       case('s'): qy.s = toJSON(query[key]); break;
       case('sk'): qy.sk = parseInt(query[key]); break;
       case('l'): qy.l = parseInt(query[key]); break;
-      case('p'): qy.p = query[key]; break;
+      case('p'):
+        if (typeof query[key] === 'string') {
+          if (query[key].indexOf('{') !== -1) query[key] = JSON.parse(query[key]);
+          else if (query[key].indexOf('[') !== -1) query[key] = JSON.parse(query[key]);
+        }
+        qy.p = query[key];
+        break;
       case('map'): qy.map = query[key]; break;
       case('reduce'): qy.reduce = query[key]; break;
       case('fl'): qy.fl = query[key]=='true'?true:false; break;


### PR DESCRIPTION
Allow to pass populate() options in the query such as  `/api/user?p={"path":"objectives","match":{"username": "bob"}` to be able to do what I wanted as explained in #2
