### PR TITLE
#6 Add oid wilcard to query ObjectId values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,9 @@
 var util = require('util')
   , flatten = require('flat').flatten
   , _ = require('lodash');
-  
+
+var ObjectId = require("mongoose").Types.ObjectId;
+
 var dbg = false;  
   
 var parseQuery = function(query, options){
@@ -250,6 +252,11 @@ var parseQuery = function(query, options){
           }
           obj[key] = new RegExp(m[1], m[2]);
         }
+      }
+      else if (value.startsWith('oid:')){
+          var oidValue = value.split(":")[1];
+
+          obj[key] = new ObjectId(oidValue);
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
       }
     ],
   "dependencies": {
-    "mongoose": ">=3.8.1",
+    "mongoose": "3.8.1",
     "flat": "*",
     "lodash": "*"
   },

--- a/test/tests.js
+++ b/test/tests.js
@@ -37,13 +37,18 @@ describe('Query:basic', function() {
     this.timeout(10000);
     
     var create = function(i, max, callback){
-      if( i<max){
+      if( i<max -1){
         var obj = new model({title: (i%2===0?'testa':'testb'), msg: 'i#'+i, orig: _id, i: i});
         obj.save( function(error, doc){
           create(i+1, max, callback);
         });
-      } else {
-        callback();
+      }
+      else {
+        var obj = new model({_id: "57ae125aaf1b792c1768982b", title: (i%2===0?'testa':'testb'), msg: 'i#'+i, orig: _id, i: i});
+        obj.save( function(error, doc){
+          callback();
+        });
+
       }
     }
     mongoose.connection.on('connected', function(){
@@ -252,6 +257,17 @@ describe('Query:basic', function() {
     model.Query(req, function(error, data){
       assert.equal(error, undefined);
       assert.equal(data.length, 2000);
+      //alternative
+      assert.instanceOf(model.Query(req), mongoose.Promise);
+      done();
+    });
+  });
+  it('oid wildcard', function(done) {
+    var req = {q:'{"_id": "oid:57ae125aaf1b792c1768982b"}'};
+    model.Query(req, function(error, data){
+      assert.equal( error, undefined );
+      assert.equal( data[0]._id, "57ae125aaf1b792c1768982b" );
+
       //alternative
       assert.instanceOf(model.Query(req), mongoose.Promise);
       done();

--- a/test/tests.js
+++ b/test/tests.js
@@ -266,6 +266,7 @@ describe('Query:basic', function() {
     var req = {q:'{"_id": "oid:57ae125aaf1b792c1768982b"}'};
     model.Query(req, function(error, data){
       assert.equal( error, undefined );
+      assert.equal( data.length, 1);
       assert.equal( data[0]._id, "57ae125aaf1b792c1768982b" );
 
       //alternative


### PR DESCRIPTION
Implementation of the wilcard oid, now it's possible to query ObjectId values:

`{"user_id": "oid:<id_value>"}`
