### PR TITLE
Major refactoring, including support for mongoose 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,15 @@ mongoose-query [![Build Status](https://travis-ci.org/jupe/mongoose-query.png?br
 
 [![NPM](https://nodei.co/npm-dl/mongoose-query.png)](https://nodei.co/npm/mongoose-query/)
 
-mongoose query creator.
-This library is usefull example with `expressjs` + `mongoose` applications to help construct mongoose query model directly from url parameters.
+This library is usefull example with `expressjs` + `mongoose` applications to help construct mongoose query model directly from url parameters. Example:
+
+```
+http://localhost/model?q={"group":"users"}&f=name&sk=1&l=5&p=name
+```
+Converted to:
+```
+model.find({group: "users"}).select("name").skip(1).limit(5).populate('name')
+```
 
 ## Changes log
 
@@ -41,17 +48,6 @@ module.exports = function query(req, res) {
   });
 }
 ```
-
-## Query string example
-
-```
-http://localhost/model?q={"group":"users"}&f=name&sk=1&l=5&p=name
-
-Converted to:
-
-model.find({group: "users"}).select("name").skip(1).limit(5).populate('name')
-```
-
 
 ## doc
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ model.find({group: "users"}).select("name").skip(1).limit(5).populate('name')
 ## doc
 
 ```
+Model.query()
+Model.leanQuery() - gives plain objects ([lean](http://mongoosejs.com/docs/api.html#query_Query-lean))
+``
+
+```
 http://www.myserver.com/query?[q=<query>][&t=<type>][&f=<fields>][&s=<order>][&sk=<skip>][&l=<limit>][&p=<populate>][&fl=<boolean>][&map=<mapFunction>][&reduce=<reduceFunction>]
 
 q=<query>                   restrict results by the specified JSON query
@@ -88,8 +93,8 @@ Alternative search conditions:
 "key={in}a,b"               At least one of these is in array
 "key={nin}a,b"              Any of these values is not in array
 "key={all}a,b"              All of these contains in array
-"key={empty}-"              Field is empty or not exists
-"key={!empty}-"             Field exists and is not empty
+"key={empty}"               Field is empty or not exists
+"key={!empty}"              Field exists and is not empty
 "key={mod}a,b"              Docs where key mod a is b
 "key={gt}a"                 Docs key is greater than a
 "key={lt}a"                 Docs key is lower than a

--- a/README.md
+++ b/README.md
@@ -53,23 +53,24 @@ module.exports = function query(req, res) {
 
 ```
 var QueryPlugin = require(mongoose-query);
-schema.plugin(QueryPlugin(, options))
+schema.plugin( QueryPlugin(, <options>) )
 ```
-options:
+optional `options`:
 * `logger`: custom logger, e.g. winston logger, default: "dummy logger"
-* `allowEval`: <boolean> Allow to use eval or not, default: false
+* `allowEval`: <boolean> Allow to use eval or not, default: true
 
 Model static methods:
 
-`model.query(<query>(, <callback>))`
+`model.query( <query>(, <callback>) )`
 
-`model.leanQuery(<query>(, <callback>))`: gives plain objects ([lean](http://mongoosejs.com/docs/api.html#query_Query-lean))
+`model.leanQuery(<query>(, <callback>) )`: gives plain objects ([lean](http://mongoosejs.com/docs/api.html#query_Query-lean))
 
-**Note:** without <callback> you get Promise.
+**Note:** without `<callback>` you get Promise.
 
 **URL API:**
 ```
-http://www.myserver.com/query?[q=<query>][&t=<type>][&f=<fields>][&s=<order>][&sk=<skip>][&l=<limit>][&p=<populate>][&fl=<boolean>][&map=<mapFunction>][&reduce=<reduceFunction>]
+http://www.myserver.com/query?[q=<query>][&t=<type>][&f=<fields>][&s=<order>][&sk=<skip>]
+[&l=<limit>][&p=<populate>][&fl=<boolean>][&map=<mapFunction>][&reduce=<reduceFunction>]
 
 q=<query>                   restrict results by the specified JSON query
                             regex e.g. q='{"field":{"$regex":"/mygrep/", "$options":"i"}}'
@@ -105,10 +106,10 @@ Alternative search conditions:
 "key={gt}a"                 Docs key is greater than a
 "key={lt}a"                 Docs key is lower than a
 "key=a|b|c"                 Docs where type of key is Array and contains at least one of given value
+```
 
-Results:
-
-fl=false
+Results with `fl=false`:
+```
 [
  {
  	nest: {
@@ -119,8 +120,10 @@ fl=false
   	}
 }
 ]
+```
 
-fl=true
+Results with `fl=true`:
+```
 [
  {'nest.ed.data': 'value',
   'nest.ed.data2':'value'},

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ mongoose-query [![Build Status](https://travis-ci.org/jupe/mongoose-query.png?br
 
 [![NPM](https://nodei.co/npm-dl/mongoose-query.png)](https://nodei.co/npm/mongoose-query/)
 
-mongoose query creator. Alternative for mongoose-api-query but without schema understanding.
-This very simple library can be used for example expressjs+mongoose applications to help
-construct mongoose query model directly from url parameters.
+mongoose query creator.
+This library is usefull example with `expressjs` + `mongoose` applications to help construct mongoose query model directly from url parameters.
 
-## History
+## Changes log
 
 |versio|Changes|
 |------|-------|
+|0.3.0|Big refactoring, see more from release note.. e.g. mongoose 4.x support|
 |0.2.1|added oid support, fixed aggregate and support mongoose => 3.8.1
 |0.2.0|replace underscore with lodash, possible to return promise when no callback in use|
 |0.1.7|typo on mapReduce case, !empty keyword added|
@@ -45,23 +45,33 @@ module.exports = function query(req, res) {
 ## Query string example
 
 ```
-http://localhost/query.json?q={"group":"users"}&f=name&sk=1&l=5&p=name
+http://localhost/model?q={"group":"users"}&f=name&sk=1&l=5&p=name
 
 Converted to:
 
 model.find({group: "users"}).select("name").skip(1).limit(5).populate('name')
 ```
 
-**note:** Seems that sorting with limit doesn't work with mongodb 2.4.x without related indexes. Mongodb 2.6.x seems to work.
-
 
 ## doc
 
 ```
-Model.query()
-Model.leanQuery() - gives plain objects ([lean](http://mongoosejs.com/docs/api.html#query_Query-lean))
-``
+var QueryPlugin = require(mongoose-query);
+schema.plugin(QueryPlugin(, options))
+```
+options:
+* `logger`: custom logger, e.g. winston logger, default: "dummy logger"
+* `allowEval`: <boolean> Allow to use eval or not, default: false
 
+Model static methods:
+
+`model.query(<query>(, <callback>))`
+
+`model.leanQuery(<query>(, <callback>))`: gives plain objects ([lean](http://mongoosejs.com/docs/api.html#query_Query-lean))
+
+**Note:** without <callback> you get Promise.
+
+**URL API:**
 ```
 http://www.myserver.com/query?[q=<query>][&t=<type>][&f=<fields>][&s=<order>][&sk=<skip>][&l=<limit>][&p=<populate>][&fl=<boolean>][&map=<mapFunction>][&reduce=<reduceFunction>]
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ mongoose-query [![Build Status](https://travis-ci.org/jupe/mongoose-query.png?br
 [![NPM](https://nodei.co/npm-dl/mongoose-query.png)](https://nodei.co/npm/mongoose-query/)
 
 mongoose query creator. Alternative for mongoose-api-query but without schema understanding.
-This very simple library can be used for example expressjs+mongoose applications to help 
+This very simple library can be used for example expressjs+mongoose applications to help
 construct mongoose query model directly from url parameters.
 
 ## History
@@ -63,11 +63,11 @@ http://www.myserver.com/query?[q=<query>][&t=<type>][&f=<fields>][&s=<order>][&s
 q=<query>                   restrict results by the specified JSON query
                             regex e.g. q='{"field":{"$regex":"/mygrep/", "$options":"i"}}'
 t=<type>                    find|findOne|count|aggregate|distinct|aggregate|mapReduce
-f=<set of fields>           specify the set of fields to include or exclude in each document 
+f=<set of fields>           specify the set of fields to include or exclude in each document
                             (1 - include; 0 - exclude)
-s=<sort order>              specify the order in which to sort each specified field 
+s=<sort order>              specify the order in which to sort each specified field
                             (1- ascending; -1 - descending), JSON
-sk=<num results to skip>    specify the number of results to skip in the result set; 
+sk=<num results to skip>    specify the number of results to skip in the result set;
                             useful for paging
 l=<limit>                   specify the limit for the number of results (default is 1000)
 p=<populate>                specify the fields for populate, also more complex json object is supported.
@@ -83,7 +83,7 @@ Special values:
 "oid:<string>"              string is converted to ObjectId
 { $regex: /<string>/,       regex match with optional regex options
  ($options: "") }        
-  
+
 Alternative search conditions:
 "key={in}a,b"               At least one of these is in array
 "key={nin}a,b"              Any of these values is not in array
@@ -97,9 +97,9 @@ Alternative search conditions:
 
 Results:
 
-fl=false 
+fl=false
 [
- { 
+ {
  	nest: {
  		ed: {
  			data: 'value',
@@ -115,7 +115,3 @@ fl=true
   'nest.ed.data2':'value'},
 ]
 ```
-
-
-
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,395 +3,131 @@
   e.g.
   var QueryPlugin = require(mongoose-query);
   schema.plugin(QueryPlugin);
-  mymodel.Query(req.query, function(error, data){
+  mymodel.query(req.query, function(error, data){
   });
-  
+
 */
-var util = require('util')
+const util = require('util')
   , flatten = require('flat').flatten
-  , _ = require('lodash');
+  , _ = require('lodash')
+  , parseQuery = require('./parseQuery')
+  , mongoose = require('mongoose');
 
-var ObjectId = require("mongoose").Types.ObjectId;
+let dummyLogger = ()=>{};
+let logger =  {
+  debug: dummyLogger, //console.log,
+  error: dummyLogger
+}
+module.exports = function QueryPlugin (schema, options) {
 
-var dbg = false;  
-  
-var parseQuery = function(query, options){
-  /**
-  
-  reserved keys: q,t,f,s,sk,l,p
-  
-  [q=<query>][&t=<type>][&f=<fields>][&s=<order>][&sk=<skip>][&l=<limit>][&p=<populate>]
-  q=<query> - restrict results by the specified JSON query
-  t=<type> - find|findOne|count|aggregate|distinct..
-  f=<set of fields> - specify the set of fields to include or exclude in each document (1 - include; 0 - exclude)
-  s=<sort order> - specify the order in which to sort each specified field (1- ascending; -1 - descending)
-  sk=<num results to skip> - specify the number of results to skip in the result set; useful for paging
-  l=<limit> - specify the limit for the number of results (default is 1000)
-  p=<populate> - specify the fields for populate
-  
-  alternative search conditions:
-  "key={in}a,b"
-  "At least one of these is in array"
-  
-  "key={nin}a,b"
-  "Any of these values is not in array"
-  
-  "key={all}a,b"
-  "All of these contains in array"
-  
-  "key={empty}-"
-   "Field is empty or not exists"
-
-  "key={!empty}-"
-   "Field exists and is not empty"
-
-  "key={mod}a,b"
-  "Docs where key mod a is b"
-  
-  "key={gt}a"
-  "Docs key is greater than a"
-  
-  "key={lt}a"
-  "Docs key is lower than a"
-  
-  "key=a|b|c"
-  "Docs where key type is Array, contains at least one of given value
-  */
-  
-  var qy = {
-    q: {},      //  query
-    map: '',
-    reduce: '',
-    t: 'find',   //  count
-    f: false,      // fields
-    s: false,      //  sort
-    sk: false,      //  skip
-    l: 1000,     //  limit
-    p: false,    //populate
-    fl: false    //flat
-  }
-  
-  var toJSON = function(str){
-    var json = {}
-    try{
-      json = JSON.parse(str);
-    } catch(e){
-      console.log('parsing error');
-      json = {};
-    } 
-    return json;
-  }
-  var convertToBoolean = function (str) {
-    if (str.toLowerCase() === "true" ||
-        str.toLowerCase() === "yes" ){
-      return true;
-    } else if (
-        str.toLowerCase() === "false" ||
-        str.toLowerCase() === "no" ){
-      return false;
-    } else {
-      return -1;
+  let doQuery = function (data, opt, callback) {
+    logger.debug('doQuery:', data, opt, callback);
+    let q = parseQuery(data, opt);
+    if(!this instanceof mongoose.Model) {
+      return q;
     }
-  }
-  var addCondition = function(key, cond)
-  {
-    if( cond['$or'] ) {
-      if( !qy.q.hasOwnProperties('$or') ){
-        qy.q['$or'] = [];
-      }
-      qy.q['$or'].push( {key: cond} );
-    } else {
-      qy.q[key] = cond;
-    }
-  }
-  function parseDate(str) {
-    //31/2/2010
-    var m = str.match(/^(\d{1,2})[\/\s\.\-\,](\d{1,2})[\/\s\.\-\,](\d{4})$/);
-    return (m) ? new Date(m[3], m[2]-1, m[1]) : null;
-  }
-  function parseDate2(str) {
-    //2010/31/2
-    var m = str.match(/^(\d{4})[\/\s\.\-\,](\d{1,2})[\/\s\.\-\,](\d{1,2})$/);
-    return (m) ? new Date(m[1], m[2]-1, m[3]) : null;
-  }
-  var isStringValidDate = function(str){
-    if(util.isDate(new Date(str)))return true;
-    if(util.isDate(parseDate(str)))return true;
-    if(util.isDate(parseDate2(str)))return true;
-    return false;
-  }
-  var parseParam = function(key, val){
-    var lcKey = key;
-
-    var operator = false;
-    if( typeof val == 'string' ){
-        operator = val.match(/\{(.*)\}/);
-        val = val.replace(/\{(.*)\}/, '');
-        if (operator){
-          operator = operator[1];
-        }
-    }
-    if( key[0] == '$' ) return; //bypass $ characters for security reasons!
-    if (val === "") {
-      return;
-    } else if (lcKey === "skips") {
-      qy.sk = parseInt(val);
-    } else if (lcKey === "select") {
-      qy.s = val;
-    } else if (lcKey === "limit") {
-      qy.l = val;
-    } else if (lcKey === "sort_by") {
-      var parts = val.split(',');
-      qy.s = {};
-      qy.s[parts[0]] = parts.length > 1 ? parseInt(parts[1]) : 1;
-    } else {
-      if( convertToBoolean(val) != -1 ) {
-        var b = convertToBoolean(val);
-        if( b == false ) {
-          var orCond = {}
-          orCond[ lcKey ] = {$exists: false};
-          qy.q[ '$or' ] = [] 
-          qy.q[ '$or' ].push(orCond);
-          orCond[ lcKey ] = b;
-          qy.q[ '$or' ].push(orCond);
-        }
-        else addCondition( lcKey, b);
-      } else {
-        if (operator === "gt" ||
-          operator === "gte" ||
-          operator === "lt" ||
-          /*operator === "in" ||
-          operator === "nin" ||*/
-          operator === "lte") {
-            if (isStringValidDate(val)) {
-              val = new Date(val);
+    logger.debug('q:', JSON.stringify(q));
+    let query;
+    switch(q.t){
+      case('find'):
+      case('findOne'):
+          query = this.find(q.q);
+          logger.debug('find:',q.q);
+          break;
+      case('count'):
+          if (!callback) {
+            return this.count(q.q);
+          }
+          this.count(q.q, function(error,count){
+            if(error) callback(error);
+            else callback(error, {count: count});
+          });
+          return;
+      case('distinct'):
+          return this.distinct(q.f, q.q, callback);
+      case('aggregate'):
+          return this.aggregate(q.q, callback);
+      case('mapReduce'):
+          var o = {};
+          try{
+            //eval("(function(x) { return x*x})");
+            o.map = eval(q.map);
+            o.reduce = eval(q.reduce);
+            o.limit = q.l;
+            o.query = q.q;
+            if( q.scope ) o.scope = JSON.parse(decodeURIComponent(q.scope));
+            if( q.finalize )  o.finalize = eval(decodeURIComponent(q.finalize));
+            logger.debug("mapReduce:",o);
+            return this.mapReduce(o, callback);
+          } catch(e){
+            if(callback) {
+              callback(e);
             }
-            tmp = {}
-            var arrayOperators = ['in', 'nin', 'all', 'mod']
-            if( arrayOperators.indexOf(operator)>=0){
-              val = val.split(',');
-              tmp = []
+            return e;
+          }
+          return;
+      default:
+          logger.error('not supported query type');
+          return;
+    }
+
+    if( ['find','findOne'].indexOf(q.t) >= 0 ){
+
+      if(q.s) query = query.sort(q.s);
+      if(q.sk) query = query.skip(q.sk);
+      if(q.l) query = query.limit(q.l);
+      if(q.f) query = query.select(q.f);
+      if(q.p) query = query.populate(q.p);
+
+      if (opt.lean) query = query.lean();
+
+      if( q.t === 'findOne' ){
+        if( q.fl ) {
+          if (!callback) {
+            return new Error("`flat` is not supported without callback");
+          }
+          query.findOne( function(error, doc){
+            if(error) callback(error);
+            else {
+              callback(error, flatten(doc));
             }
-            tmp["$"+operator] =  val;
-            
-            
-            addCondition(lcKey, tmp);
-            
-        } else if(operator == 'i') {
-          addCondition(lcKey, new RegExp('^'+val+'$', 'i')); //http://scriptular.com/
-        } else if(operator == 'e') {
-          addCondition(lcKey, new RegExp(val+'$'));
-        } else if(operator == 'b') {
-          addCondition(lcKey, new RegExp('^' + val));
-        } else if(operator == 'in') {
-          var parts = val.split(',');
-          addCondition(lcKey, {'$in': parts } );
-        } else if(operator == 'ne') {
-          addCondition(lcKey, {'$ne': val } );
-        } else if(operator == 'nin') {
-          var parts = val.split(',');
-          addCondition(lcKey, {'$nin': parts } );
-        } else if(operator == 'all') {
-          var parts = val.split(',');
-          addCondition(lcKey, {'$all': parts } );
-        } else if(operator == 'size') {
-          addCondition(lcKey, {'$size': val } );
-        } else if(operator == 'm') {
-          // key={m}<key>,<value>
-          value = value.split(',');
-          qy.q[ key ] = {};
-          qy.q[ key ]['$elemMatch']  = {};
-          qy.q[ key]['$elemMatch']['key']  = value[0];
-          qy.q[ key]['$elemMatch']['value']  = value[1];
-        } else if(operator == 'empty') {
-          var empty = {};
-          empty[lcKey] = '';
-          var unexists =  {};
-          unexists[lcKey] = {$exists: false};
-          addCondition('$or', [ empty, unexists ] );
-        } else if(operator == '!empty') {
-            var empty = {};
-            empty[lcKey] = '';
-            var unexists =  {};
-            unexists[lcKey] = {$exists: false};
-            addCondition('$nor', [ empty, unexists ] );
-        } else if(operator == 'c') {
-          val = val.split('/');
-          addCondition(lcKey, new RegExp(val[0], val[1]));
+          })
         } else {
-          if (options.ignoreKeys === true) return;
-          if (options.ignoreKeys && typeof options.ignoreKeys.indexOf === 'function' && options.ignoreKeys.indexOf(key) != -1) return;
-          var parts = val.split('|');
-          if( parts.length > 1){
-            var arr = []
-            for(i=0;i<parts.length;i++){
-              tmp = {}
-              tmp[lcKey] = parts[i];
-              arr.push( tmp );
+          return query.findOne(callback);
+        }
+      } else {
+        if( q.fl ) {
+          if (!callback) {
+            return new Error("`flat` is not supported without callback");
+          }
+          query.find( function(error, docs){
+            if(error) callback(error);
+            else {
+              var arr = [];
+              docs.forEach( function(doc){
+                var json = doc.toJSON({virtuals: true});
+                arr.push( flatten(json));
+              });
+              callback(error, arr);
             }
-            addCondition('$or', arr );
-          } else {
-            addCondition(lcKey, val );
-          }
+          })
+        } else {
+          logger.debug('find..', callback);
+          return query.exec(callback);
         }
       }
     }
   }
-  function walker(value, key, obj) {
-    if (value !== null && typeof value === "object") {
-        // Recurse into children
-        _.each(value, walker);
-    } else if( typeof value === "string" ) {
-      if( key === '$regex' ) {
-        var m = value.match(/\/(.*)\//);
-        if(m) {
-          var options;
-          if(obj['$options'] ) {
-            m[2] = obj['$options']
-            delete obj['$options'];
-          }
-          obj[key] = new RegExp(m[1], m[2]);
-        }
-      }
-      else if (value.startsWith('oid:')){
-          var oidValue = value.split(":")[1];
-          obj[key] = new ObjectId(oidValue);
-      }
-    }
-  }
-  for(var key in query){
-    switch(key) {
-      case('q'): 
-        qy.q = toJSON(decodeURIComponent(query[key]));
-        _.each(qy.q, walker);
-        break;
-      case('t'): qy.t = query[key]; break;
-      case('f'): qy.f = query[key]; break;
-      case('s'): qy.s = toJSON(query[key]); break;
-      case('sk'): qy.sk = parseInt(query[key]); break;
-      case('l'): qy.l = parseInt(query[key]); break;
-      case('p'):
-        if (typeof query[key] === 'string') {
-          if (query[key].indexOf('{') !== -1) query[key] = JSON.parse(decodeURIComponent(query[key]));
-          else if (query[key].indexOf('[') !== -1) query[key] = JSON.parse(decodeURIComponent(query[key]));
-        }
-        qy.p = query[key];
-        break;
-      case('map'): qy.map = query[key]; break;
-      case('reduce'): qy.reduce = query[key]; break;
-      case('fl'): qy.fl = query[key]=='true'?true:false; break;
-      default: 
-        parseParam(key, query[key]);
-        break;
-    }
-  }
-  return qy;
-}
-var doQuery = function(query, model, options, callback)
-{
-  if(dbg)console.log(query);
-  var q = parseQuery(query, options);
-  if(!model)return q;
-  if(dbg)console.log(q);
-  var find = model;
-  switch(q.t){
-    case('find'): 
-    case('findOne'):    
-        find = find.find(q.q);
-        break;
-    case('count'):
-        if (!callback) {
-          return find.count(q.q); 
-        }
-        find.count(q.q, function(error,count){
-          if(error) callback(error);
-          else callback(error, {count: count});
-        });
-        return;
-    case('distinct'):
-        return find.distinct(q.f, q.q, callback); 
-    case('aggregate'):
-        return find.aggregate(q.q, callback);
-    case('mapReduce'):
-        var o = {};
-        try{
-          //eval("(function(x) { return x*x})");
-          o.map = eval(q.map);
-          o.reduce = eval(q.reduce);
-          o.limit = q.l;
-          o.query = q.q;
-          if( q.scope ) o.scope = JSON.parse(decodeURIComponent(q.scope));
-          if( q.finalize )  o.finalize = eval(decodeURIComponent(q.finalize));
-          if(dbg)console.log(o);
-          return find.mapReduce(o, callback);
-        } catch(e){
-          if(callback) {
-            callback(e);
-          }
-          return e;
-        }
-        return;
-    default: 
-        console.log('not supported query type');
-        return;
-  }
-  
-  if( ['find','findOne'].indexOf(q.t) >= 0 ){
-    
-    if(q.s) find = find.sort(q.s);
-    if(q.sk) find = find.skip(q.sk);
-    if(q.l) find = find.limit(q.l);
-    if(q.f) find = find.select(q.f);
-    if(q.p) find = find.populate(q.p);
+  let qOpts = _.defaults({lean: false}, options);
+  let query = function (data, callback) {
+    return doQuery.bind(this)(data, qOpts, callback);
+  };
+  schema.static('query', query);
+  schema.static('urlQuery', query);
 
-    if (options.lean) find = find.lean();
-    
-    if( q.t === 'findOne' ){
-      if( q.fl ) {
-        if (!callback) {
-          return new Error("`flat` is not supported without callback"); 
-        }
-        find.findOne( function(error, doc){
-          if(error) callback(error);
-          else {
-            callback(error, flatten(doc));
-          }
-        })
-      } else {
-        return find.findOne(callback);
-      }
-    } else {
-      if( q.fl ) {
-        if (!callback) {
-          return new Error("`flat` is not supported without callback");
-        }
-        find.find( function(error, docs){
-          if(error) callback(error);
-          else {
-            var arr = [];
-            docs.forEach( function(doc){
-              var json = doc.toJSON({virtuals: true});
-              arr.push( flatten(json));
-            });
-            callback(error, arr);
-          }
-        })
-      } else {
-        return find.exec(callback);
-      }
-    }  
+  let lOpts = _.defaults({lean: true}, options);
+  let leanQuery = function (query, callback) {
+    return doQuery.bind(this)(query, lOpts, callback);
   }
-}
-
-module.exports = exports = function QueryPlugin(schema, options) {
-  schema.statics.query = schema.statics.Query = function(query, callback){
-    options = options || {};
-    options.lean = false;
-    return doQuery(query, this, options, callback)
-  }
-  schema.statics.leanQuery = schema.statics.leanQuery = function(query, callback){
-    options = options || {};
-    options.lean = true;
-    return doQuery(query, this, options, callback)
-  }
+  schema.static('leanQuery', leanQuery);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,24 +1,33 @@
 /**
   MONGOOSE QUERY GENERATOR FROM HTTP URL
   e.g.
-  var QueryPlugin = require(mongoose-query);
+  let QueryPlugin = require(mongoose-query);
   schema.plugin(QueryPlugin);
   mymodel.query(req.query, function(error, data){
   });
 
 */
-const util = require('util')
-  , flatten = require('flat').flatten
+const flatten = require('flat').flatten
   , _ = require('lodash')
+  , mongoose = require('mongoose')
   , parseQuery = require('./parseQuery')
-  , mongoose = require('mongoose');
+  , logger = require('./logger');
 
-let dummyLogger = ()=>{};
-let logger =  {
-  debug: dummyLogger, //console.log,
-  error: dummyLogger
-}
 module.exports = function QueryPlugin (schema, options) {
+
+  options = options || {};
+  if(_.has(options, 'logger')) {
+    logger.setLogger(logger);
+  }
+  let allowEval = _.get(options, 'allowEval', true);
+  let doEval = (str) => {
+    if(allowEval) {
+      return eval(str);
+    } else {
+      return false;
+    }
+  }
+  options = _.omit(options, ['logger', 'allowEval', 'lean']);
 
   let doQuery = function (data, opt, callback) {
     logger.debug('doQuery:', data, opt, callback);
@@ -38,9 +47,9 @@ module.exports = function QueryPlugin (schema, options) {
           if (!callback) {
             return this.count(q.q);
           }
-          this.count(q.q, function(error,count){
+          this.count(q.q, (error,count) => {
             if(error) callback(error);
-            else callback(error, {count: count});
+            else callback(error, {count});
           });
           return;
       case('distinct'):
@@ -48,15 +57,15 @@ module.exports = function QueryPlugin (schema, options) {
       case('aggregate'):
           return this.aggregate(q.q, callback);
       case('mapReduce'):
-          var o = {};
+          let o = {};
           try{
             //eval("(function(x) { return x*x})");
-            o.map = eval(q.map);
-            o.reduce = eval(q.reduce);
+            o.map = doEval(q.map);
+            o.reduce = doEval(q.reduce);
             o.limit = q.l;
             o.query = q.q;
             if( q.scope ) o.scope = JSON.parse(decodeURIComponent(q.scope));
-            if( q.finalize )  o.finalize = eval(decodeURIComponent(q.finalize));
+            if( q.finalize )  o.finalize = doEval(decodeURIComponent(q.finalize));
             logger.debug("mapReduce:",o);
             return this.mapReduce(o, callback);
           } catch(e){
@@ -78,39 +87,54 @@ module.exports = function QueryPlugin (schema, options) {
       if(q.l) query = query.limit(q.l);
       if(q.f) query = query.select(q.f);
       if(q.p) query = query.populate(q.p);
-
-      if (opt.lean) query = query.lean();
-
+      if(opt.lean) query = query.lean();
       if( q.t === 'findOne' ){
         if( q.fl ) {
-          if (!callback) {
-            return new Error("`flat` is not supported without callback");
+          if (callback) {
+            query.findOne((error, doc) => {
+              if(error) callback(error);
+              else callback(error, flatten(doc));
+            });
+          } else {
+            return new Promise((resolve, reject) => {
+              query.findOne((error, doc) => {
+                if(error) reject(error);
+                else resolve(flatten(doc));
+              });
+            });
           }
-          query.findOne( function(error, doc){
-            if(error) callback(error);
-            else {
-              callback(error, flatten(doc));
-            }
-          })
         } else {
           return query.findOne(callback);
         }
       } else {
         if( q.fl ) {
-          if (!callback) {
-            return new Error("`flat` is not supported without callback");
-          }
-          query.find( function(error, docs){
-            if(error) callback(error);
-            else {
-              var arr = [];
-              docs.forEach( function(doc){
-                var json = doc.toJSON({virtuals: true});
-                arr.push( flatten(json));
+          if (callback) {
+            query.find((error, docs) => {
+              if(error) callback(error);
+              else {
+                let arr = [];
+                docs.forEach((doc) => {
+                  let json = doc.toJSON({virtuals: true});
+                  arr.push( flatten(json));
+                });
+                callback(error, arr);
+              }
+            });
+          } else {
+            return new Promise((resolve, reject) => {
+              query.find((error, docs) => {
+                if(error) reject(error);
+                else {
+                  let arr = [];
+                  docs.forEach((doc) => {
+                    let json = doc.toJSON({virtuals: true});
+                    arr.push( flatten(json));
+                  });
+                  resolve(arr);
+                }
               });
-              callback(error, arr);
-            }
-          })
+            });
+          }
         } else {
           logger.debug('find..', callback);
           return query.exec(callback);
@@ -118,16 +142,15 @@ module.exports = function QueryPlugin (schema, options) {
       }
     }
   }
-  let qOpts = _.defaults({lean: false}, options);
   let query = function (data, callback) {
-    return doQuery.bind(this)(data, qOpts, callback);
+    return doQuery.bind(this)(data, options, callback);
   };
   schema.static('query', query);
-  schema.static('urlQuery', query);
 
-  let lOpts = _.defaults({lean: true}, options);
-  let leanQuery = function (query, callback) {
-    return doQuery.bind(this)(query, lOpts, callback);
-  }
+  let leanQuery = function (data, callback) {
+    return doQuery.bind(this)(data,
+        _.defaults({lean: true}, options),
+        callback);
+  };
   schema.static('leanQuery', leanQuery);
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,25 @@
+const _ = require('lodash');
+const dummy = () => {};
+class Logger {
+    constructor() {
+        this._logger = this._getDummyLogger();
+    }
+    _getDummyLogger() {
+        return {
+            silly: dummy,
+            warn: dummy,
+            error: dummy,
+            info: dummy,
+            debug: dummy
+        };
+    }
+    get silly() { return this._logger.silly; }
+    get warn() { return this._logger.warn; }
+    get error() { return this._logger.error; }
+    get info() { return this._logger.info; }
+    get debug() { return this._logger.debug; }
+    setLogger(logger) {
+        this._logger = logger;
+    }
+}
+module.exports = new Logger();

--- a/lib/parseQuery.js
+++ b/lib/parseQuery.js
@@ -1,7 +1,12 @@
-const util = require('util')
-  , _ = require('lodash')
+const _ = require('lodash')
   , mongoose = require('mongoose')
-  , ObjectId = mongoose.Types.ObjectId;
+  , ObjectId = mongoose.Types.ObjectId
+  // module tools
+  , logger = require('./logger')
+  , tools = require('./tools')
+  , toBool = tools.toBool
+  , toJSON = tools.toJSON
+  , isStringValidDate = tools.isStringValidDate;
 
 module.exports = function parseQuery(query, options){
   /**
@@ -46,97 +51,55 @@ module.exports = function parseQuery(query, options){
   "Docs where key type is Array, contains at least one of given value
   */
 
-  var qy = {
-    q: {},      //  query
+  options = options || {};
+
+  let qy = {
+    q: {},        //  query
     map: '',
     reduce: '',
-    t: 'find',   //  count
-    f: false,      // fields
-    s: false,      //  sort
-    sk: false,      //  skip
-    l: 1000,     //  limit
-    p: false,    //populate
-    fl: false    //flat
+    t: 'find',    //  count
+    f: false,     // fields
+    s: false,     //  sort
+    sk: false,    //  skip
+    l: 1000,      //  limit
+    p: false,     // populate
+    fl: false    // flat
   }
 
-  var toJSON = function(str){
-    var json = {}
-    try{
-      json = JSON.parse(str);
-    } catch(e){
-      console.log('parsing error');
-      json = {};
-    }
-    return json;
-  }
-  var convertToBoolean = function (str) {
-    if (str.toLowerCase() === "true" ||
-        str.toLowerCase() === "yes" ){
-      return true;
-    } else if (
-        str.toLowerCase() === "false" ||
-        str.toLowerCase() === "no" ){
-      return false;
-    } else {
-      return -1;
-    }
-  }
-  var addCondition = function(key, cond)
+  let addCondition = function(key, val)
   {
-    if( cond['$or'] ) {
-      if( !qy.q.hasOwnProperties('$or') ){
-        qy.q['$or'] = [];
+    if (["$or", "$nor", "$and"].indexOf(key)!==-1) {
+      if (!_.has(qy.q, key)) {
+        qy.q[key] = [];
       }
-      qy.q['$or'].push( {key: cond} );
+      qy.q[key].push(val);
     } else {
-      qy.q[key] = cond;
+      qy.q[key] = val;
     }
   }
-  function parseDate(str) {
-    //31/2/2010
-    var m = str.match(/^(\d{1,2})[\/\s\.\-\,](\d{1,2})[\/\s\.\-\,](\d{4})$/);
-    return (m) ? new Date(m[3], m[2]-1, m[1]) : null;
-  }
-  function parseDate2(str) {
-    //2010/31/2
-    var m = str.match(/^(\d{4})[\/\s\.\-\,](\d{1,2})[\/\s\.\-\,](\d{1,2})$/);
-    return (m) ? new Date(m[1], m[2]-1, m[3]) : null;
-  }
-  var isStringValidDate = function(str){
-    if(util.isDate(new Date(str)))return true;
-    if(util.isDate(parseDate(str)))return true;
-    if(util.isDate(parseDate2(str)))return true;
-    return false;
-  }
-  var parseParam = function(key, val){
-    var lcKey = key;
 
-    var operator = false;
-    if( typeof val == 'string' ){
+  let parseParam = function(key, val){
+    let lcKey = key;
+    let operator = false;
+    if (typeof val == 'string') {
         operator = val.match(/\{(.*)\}/);
-        val = val.replace(/\{(.*)\}/, '');
         if (operator){
+          val = val.replace(/\{(.*)\}/, '');
           operator = operator[1];
         }
     }
-    if( key[0] == '$' ) return; //bypass $ characters for security reasons!
-    if (val === "") {
+    if (key[0] == '$' ) return; //bypass $ characters for security reasons!
+    if (val === "" && operator !== 'empty' && operator !== '!empty') {
       return;
-    } else if (lcKey === "skips") {
-      qy.sk = parseInt(val);
-    } else if (lcKey === "select") {
-      qy.s = val;
-    } else if (lcKey === "limit") {
-      qy.l = val;
     } else if (lcKey === "sort_by") {
-      var parts = val.split(',');
+      let parts = val.split(',');
       qy.s = {};
       qy.s[parts[0]] = parts.length > 1 ? parseInt(parts[1]) : 1;
     } else {
-      if( convertToBoolean(val) != -1 ) {
-        var b = convertToBoolean(val);
-        if( b == false ) {
-          var orCond = {}
+      if (toBool(val) !== -1) {
+        let b = toBool(val);
+        if (b == false) {
+          let orCond = {}
           orCond[ lcKey ] = {$exists: false};
           qy.q[ '$or' ] = []
           qy.q[ '$or' ].push(orCond);
@@ -148,76 +111,64 @@ module.exports = function parseQuery(query, options){
         if (operator === "gt" ||
           operator === "gte" ||
           operator === "lt" ||
-          /*operator === "in" ||
-          operator === "nin" ||*/
-          operator === "lte") {
+          operator === "in" ||
+          operator === "nin" ||
+          operator === "lte" ||
+          operator === "ne" ||
+          operator === "size") {
             if (isStringValidDate(val)) {
               val = new Date(val);
             }
-            tmp = {}
-            var arrayOperators = ['in', 'nin', 'all', 'mod']
-            if( arrayOperators.indexOf(operator)>=0){
+            let tmp = {}
+            let arrayOperators = ['in', 'nin', 'all', 'mod']
+            if (_.indexOf(arrayOperators, operator)!==-1) {
               val = val.split(',');
-              tmp = []
             }
             tmp["$"+operator] =  val;
-
-
             addCondition(lcKey, tmp);
-
-        } else if(operator == 'i') {
+        } else if (operator == 'i') {
           addCondition(lcKey, new RegExp('^'+val+'$', 'i')); //http://scriptular.com/
-        } else if(operator == 'e') {
+        } else if (operator == 'e') {
           addCondition(lcKey, new RegExp(val+'$'));
-        } else if(operator == 'b') {
+        } else if (operator == 'b') {
           addCondition(lcKey, new RegExp('^' + val));
-        } else if(operator == 'in') {
-          var parts = val.split(',');
-          addCondition(lcKey, {'$in': parts } );
-        } else if(operator == 'ne') {
-          addCondition(lcKey, {'$ne': val } );
-        } else if(operator == 'nin') {
-          var parts = val.split(',');
-          addCondition(lcKey, {'$nin': parts } );
-        } else if(operator == 'all') {
-          var parts = val.split(',');
-          addCondition(lcKey, {'$all': parts } );
-        } else if(operator == 'size') {
-          addCondition(lcKey, {'$size': val } );
-        } else if(operator == 'm') {
+        } else if (operator == 'm') {
           // key={m}<key>,<value>
-          value = value.split(',');
-          qy.q[ key ] = {};
-          qy.q[ key ]['$elemMatch']  = {};
-          qy.q[ key]['$elemMatch']['key']  = value[0];
-          qy.q[ key]['$elemMatch']['value']  = value[1];
-        } else if(operator == 'empty') {
-          var empty = {};
+          let value = val.split(',');
+          qy.q[key] = {};
+          qy.q[key]['$elemMatch']  = {};
+          qy.q[key]['$elemMatch']['key']  = value[0];
+          qy.q[key]['$elemMatch']['value']  = value[1];
+        } else if (operator == 'empty') {
+          let empty = {};
           empty[lcKey] = '';
-          var unexists =  {};
+          let unexists =  {};
           unexists[lcKey] = {$exists: false};
-          addCondition('$or', [ empty, unexists ] );
-        } else if(operator == '!empty') {
-            var empty = {};
+          addCondition('$or', empty);
+          addCondition('$or', unexists);
+        } else if (operator == '!empty') {
+            let empty = {};
             empty[lcKey] = '';
-            var unexists =  {};
+            let unexists =  {};
             unexists[lcKey] = {$exists: false};
-            addCondition('$nor', [ empty, unexists ] );
-        } else if(operator == 'c') {
+            addCondition('$nor', empty);
+            addCondition('$nor', unexists);
+        } else if (operator == 'c') {
           val = val.split('/');
           addCondition(lcKey, new RegExp(val[0], val[1]));
         } else {
-          if (options.ignoreKeys === true) return;
-          if (options.ignoreKeys && typeof options.ignoreKeys.indexOf === 'function' && options.ignoreKeys.indexOf(key) != -1) return;
-          var parts = val.split('|');
-          if( parts.length > 1){
-            var arr = []
+          if ((options.ignoreKeys === true) ||
+            (_.isArray(options.ignoreKeys) &&
+             (options.ignoreKeys.indexOf(key) !== -1))) {
+              return;
+          }
+          let parts = val.split('|');
+          if (parts.length > 1) {
             for(i=0;i<parts.length;i++){
-              tmp = {}
+              let tmp = {}
               tmp[lcKey] = parts[i];
-              arr.push( tmp );
+              addCondition('$or', tmp);
             }
-            addCondition('$or', arr );
           } else {
             addCondition(lcKey, val );
           }
@@ -229,11 +180,10 @@ module.exports = function parseQuery(query, options){
     if (value !== null && typeof value === "object") {
         // Recurse into children
         _.each(value, walker);
-    } else if( typeof value === "string" ) {
+    } else if (typeof value === "string") {
       if( key === '$regex' ) {
-        var m = value.match(/\/(.*)\//);
+        let m = value.match(/\/(.*)\//);
         if(m) {
-          var options;
           if(obj['$options'] ) {
             m[2] = obj['$options']
             delete obj['$options'];
@@ -241,33 +191,46 @@ module.exports = function parseQuery(query, options){
           obj[key] = new RegExp(m[1], m[2]);
         }
       }
-      else if (value.startsWith('oid:')){
-          var oidValue = value.split(":")[1];
+      else if (value.startsWith('oid:')) {
+          let oidValue = value.split(":")[1];
           obj[key] = new ObjectId(oidValue);
       }
     }
   }
-  for(var key in query){
+  for(let key in query) {
     switch(key) {
       case('q'):
         qy.q = toJSON(decodeURIComponent(query[key]));
         _.each(qy.q, walker);
         break;
       case('t'): qy.t = query[key]; break;
-      case('f'): qy.f = query[key]; break;
-      case('s'): qy.s = toJSON(query[key]); break;
-      case('sk'): qy.sk = parseInt(query[key]); break;
-      case('l'): qy.l = parseInt(query[key]); break;
+      case('f'):
+      case('select'):
+        qy.f = query[key]; break;
+      case('s'):
+      case('sort'):
+        qy.s = toJSON(query[key]); break;
+      case('sk'):
+      case('skip'):
+      case('skips'):
+        qy.sk = parseInt(query[key]); break;
+      case('l'):
+      case('limit'):
+        qy.l = parseInt(query[key]); break;
       case('p'):
         if (typeof query[key] === 'string') {
-          if (query[key].indexOf('{') !== -1) query[key] = JSON.parse(decodeURIComponent(query[key]));
-          else if (query[key].indexOf('[') !== -1) query[key] = JSON.parse(decodeURIComponent(query[key]));
+          if (query[key].startsWith('{') ||
+              query[key].startsWith('[')) {
+            query[key] = JSON.parse(decodeURIComponent(query[key]));
+          } else if(query[key].indexOf(',') !== -1) {
+            query[key] = query[key].split(',');
+          }
         }
         qy.p = query[key];
         break;
       case('map'): qy.map = query[key]; break;
       case('reduce'): qy.reduce = query[key]; break;
-      case('fl'): qy.fl = query[key]=='true'?true:false; break;
+      case('fl'): qy.fl = toBool(query[key]); break;
       default:
         parseParam(key, query[key]);
         break;

--- a/lib/parseQuery.js
+++ b/lib/parseQuery.js
@@ -1,0 +1,277 @@
+const util = require('util')
+  , _ = require('lodash')
+  , mongoose = require('mongoose')
+  , ObjectId = mongoose.Types.ObjectId;
+
+module.exports = function parseQuery(query, options){
+  /**
+
+  reserved keys: q,t,f,s,sk,l,p
+
+  [q=<query>][&t=<type>][&f=<fields>][&s=<order>][&sk=<skip>][&l=<limit>][&p=<populate>]
+  q=<query> - restrict results by the specified JSON query
+  t=<type> - find|findOne|count|aggregate|distinct..
+  f=<set of fields> - specify the set of fields to include or exclude in each document (1 - include; 0 - exclude)
+  s=<sort order> - specify the order in which to sort each specified field (1- ascending; -1 - descending)
+  sk=<num results to skip> - specify the number of results to skip in the result set; useful for paging
+  l=<limit> - specify the limit for the number of results (default is 1000)
+  p=<populate> - specify the fields for populate
+
+  alternative search conditions:
+  "key={in}a,b"
+  "At least one of these is in array"
+
+  "key={nin}a,b"
+  "Any of these values is not in array"
+
+  "key={all}a,b"
+  "All of these contains in array"
+
+  "key={empty}-"
+   "Field is empty or not exists"
+
+  "key={!empty}-"
+   "Field exists and is not empty"
+
+  "key={mod}a,b"
+  "Docs where key mod a is b"
+
+  "key={gt}a"
+  "Docs key is greater than a"
+
+  "key={lt}a"
+  "Docs key is lower than a"
+
+  "key=a|b|c"
+  "Docs where key type is Array, contains at least one of given value
+  */
+
+  var qy = {
+    q: {},      //  query
+    map: '',
+    reduce: '',
+    t: 'find',   //  count
+    f: false,      // fields
+    s: false,      //  sort
+    sk: false,      //  skip
+    l: 1000,     //  limit
+    p: false,    //populate
+    fl: false    //flat
+  }
+
+  var toJSON = function(str){
+    var json = {}
+    try{
+      json = JSON.parse(str);
+    } catch(e){
+      console.log('parsing error');
+      json = {};
+    }
+    return json;
+  }
+  var convertToBoolean = function (str) {
+    if (str.toLowerCase() === "true" ||
+        str.toLowerCase() === "yes" ){
+      return true;
+    } else if (
+        str.toLowerCase() === "false" ||
+        str.toLowerCase() === "no" ){
+      return false;
+    } else {
+      return -1;
+    }
+  }
+  var addCondition = function(key, cond)
+  {
+    if( cond['$or'] ) {
+      if( !qy.q.hasOwnProperties('$or') ){
+        qy.q['$or'] = [];
+      }
+      qy.q['$or'].push( {key: cond} );
+    } else {
+      qy.q[key] = cond;
+    }
+  }
+  function parseDate(str) {
+    //31/2/2010
+    var m = str.match(/^(\d{1,2})[\/\s\.\-\,](\d{1,2})[\/\s\.\-\,](\d{4})$/);
+    return (m) ? new Date(m[3], m[2]-1, m[1]) : null;
+  }
+  function parseDate2(str) {
+    //2010/31/2
+    var m = str.match(/^(\d{4})[\/\s\.\-\,](\d{1,2})[\/\s\.\-\,](\d{1,2})$/);
+    return (m) ? new Date(m[1], m[2]-1, m[3]) : null;
+  }
+  var isStringValidDate = function(str){
+    if(util.isDate(new Date(str)))return true;
+    if(util.isDate(parseDate(str)))return true;
+    if(util.isDate(parseDate2(str)))return true;
+    return false;
+  }
+  var parseParam = function(key, val){
+    var lcKey = key;
+
+    var operator = false;
+    if( typeof val == 'string' ){
+        operator = val.match(/\{(.*)\}/);
+        val = val.replace(/\{(.*)\}/, '');
+        if (operator){
+          operator = operator[1];
+        }
+    }
+    if( key[0] == '$' ) return; //bypass $ characters for security reasons!
+    if (val === "") {
+      return;
+    } else if (lcKey === "skips") {
+      qy.sk = parseInt(val);
+    } else if (lcKey === "select") {
+      qy.s = val;
+    } else if (lcKey === "limit") {
+      qy.l = val;
+    } else if (lcKey === "sort_by") {
+      var parts = val.split(',');
+      qy.s = {};
+      qy.s[parts[0]] = parts.length > 1 ? parseInt(parts[1]) : 1;
+    } else {
+      if( convertToBoolean(val) != -1 ) {
+        var b = convertToBoolean(val);
+        if( b == false ) {
+          var orCond = {}
+          orCond[ lcKey ] = {$exists: false};
+          qy.q[ '$or' ] = []
+          qy.q[ '$or' ].push(orCond);
+          orCond[ lcKey ] = b;
+          qy.q[ '$or' ].push(orCond);
+        }
+        else addCondition( lcKey, b);
+      } else {
+        if (operator === "gt" ||
+          operator === "gte" ||
+          operator === "lt" ||
+          /*operator === "in" ||
+          operator === "nin" ||*/
+          operator === "lte") {
+            if (isStringValidDate(val)) {
+              val = new Date(val);
+            }
+            tmp = {}
+            var arrayOperators = ['in', 'nin', 'all', 'mod']
+            if( arrayOperators.indexOf(operator)>=0){
+              val = val.split(',');
+              tmp = []
+            }
+            tmp["$"+operator] =  val;
+
+
+            addCondition(lcKey, tmp);
+
+        } else if(operator == 'i') {
+          addCondition(lcKey, new RegExp('^'+val+'$', 'i')); //http://scriptular.com/
+        } else if(operator == 'e') {
+          addCondition(lcKey, new RegExp(val+'$'));
+        } else if(operator == 'b') {
+          addCondition(lcKey, new RegExp('^' + val));
+        } else if(operator == 'in') {
+          var parts = val.split(',');
+          addCondition(lcKey, {'$in': parts } );
+        } else if(operator == 'ne') {
+          addCondition(lcKey, {'$ne': val } );
+        } else if(operator == 'nin') {
+          var parts = val.split(',');
+          addCondition(lcKey, {'$nin': parts } );
+        } else if(operator == 'all') {
+          var parts = val.split(',');
+          addCondition(lcKey, {'$all': parts } );
+        } else if(operator == 'size') {
+          addCondition(lcKey, {'$size': val } );
+        } else if(operator == 'm') {
+          // key={m}<key>,<value>
+          value = value.split(',');
+          qy.q[ key ] = {};
+          qy.q[ key ]['$elemMatch']  = {};
+          qy.q[ key]['$elemMatch']['key']  = value[0];
+          qy.q[ key]['$elemMatch']['value']  = value[1];
+        } else if(operator == 'empty') {
+          var empty = {};
+          empty[lcKey] = '';
+          var unexists =  {};
+          unexists[lcKey] = {$exists: false};
+          addCondition('$or', [ empty, unexists ] );
+        } else if(operator == '!empty') {
+            var empty = {};
+            empty[lcKey] = '';
+            var unexists =  {};
+            unexists[lcKey] = {$exists: false};
+            addCondition('$nor', [ empty, unexists ] );
+        } else if(operator == 'c') {
+          val = val.split('/');
+          addCondition(lcKey, new RegExp(val[0], val[1]));
+        } else {
+          if (options.ignoreKeys === true) return;
+          if (options.ignoreKeys && typeof options.ignoreKeys.indexOf === 'function' && options.ignoreKeys.indexOf(key) != -1) return;
+          var parts = val.split('|');
+          if( parts.length > 1){
+            var arr = []
+            for(i=0;i<parts.length;i++){
+              tmp = {}
+              tmp[lcKey] = parts[i];
+              arr.push( tmp );
+            }
+            addCondition('$or', arr );
+          } else {
+            addCondition(lcKey, val );
+          }
+        }
+      }
+    }
+  }
+  function walker(value, key, obj) {
+    if (value !== null && typeof value === "object") {
+        // Recurse into children
+        _.each(value, walker);
+    } else if( typeof value === "string" ) {
+      if( key === '$regex' ) {
+        var m = value.match(/\/(.*)\//);
+        if(m) {
+          var options;
+          if(obj['$options'] ) {
+            m[2] = obj['$options']
+            delete obj['$options'];
+          }
+          obj[key] = new RegExp(m[1], m[2]);
+        }
+      }
+      else if (value.startsWith('oid:')){
+          var oidValue = value.split(":")[1];
+          obj[key] = new ObjectId(oidValue);
+      }
+    }
+  }
+  for(var key in query){
+    switch(key) {
+      case('q'):
+        qy.q = toJSON(decodeURIComponent(query[key]));
+        _.each(qy.q, walker);
+        break;
+      case('t'): qy.t = query[key]; break;
+      case('f'): qy.f = query[key]; break;
+      case('s'): qy.s = toJSON(query[key]); break;
+      case('sk'): qy.sk = parseInt(query[key]); break;
+      case('l'): qy.l = parseInt(query[key]); break;
+      case('p'):
+        if (typeof query[key] === 'string') {
+          if (query[key].indexOf('{') !== -1) query[key] = JSON.parse(decodeURIComponent(query[key]));
+          else if (query[key].indexOf('[') !== -1) query[key] = JSON.parse(decodeURIComponent(query[key]));
+        }
+        qy.p = query[key];
+        break;
+      case('map'): qy.map = query[key]; break;
+      case('reduce'): qy.reduce = query[key]; break;
+      case('fl'): qy.fl = query[key]=='true'?true:false; break;
+      default:
+        parseParam(key, query[key]);
+        break;
+    }
+  }
+  return qy;
+}

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,0 +1,44 @@
+const util = require('util')
+  , logger = require('./logger');
+
+module.exports.toJSON = function(str){
+  var json = {}
+  try{
+    json = JSON.parse(str);
+  } catch(e){
+    logger.warn('parsing error:', e);
+    json = {};
+  }
+  return json;
+}
+module.exports.toBool = function (str) {
+  if (str.toLowerCase() === "true" ||
+      str.toLowerCase() === "yes" ){
+    return true;
+  } else if (
+      str.toLowerCase() === "false" ||
+      str.toLowerCase() === "no" ){
+    return false;
+  } else {
+    return -1;
+  }
+}
+function parseDate(str) {
+  //31/2/2010
+  var m = str.match(/^(\d{1,2})[\/\s\.\-\,](\d{1,2})[\/\s\.\-\,](\d{4})$/);
+  return (m) ? new Date(m[3], m[2]-1, m[1]) : null;
+}
+function parseDate2(str) {
+  //2010/31/2
+  var m = str.match(/^(\d{4})[\/\s\.\-\,](\d{1,2})[\/\s\.\-\,](\d{1,2})$/);
+  return (m) ? new Date(m[1], m[2]-1, m[3]) : null;
+}
+function isDate(val) {
+  return util.isDate(val) && !isNaN(val.getTime());
+}
+module.exports.isStringValidDate = function(str){
+  if(isDate(new Date(str)))return true;
+  if(isDate(parseDate(str)))return true;
+  if(isDate(parseDate2(str)))return true;
+  return false;
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mongoose-query",
   "description": "mongoose Query lib",
   "keywords": ["mongoose", "query", "mongodb"],
-  "version": "0.2.1",
+  "version": "0.3.0",
   "homepage": "https://github.com/jupe/mongoose-query",
   "author": "Jussi Vatjus-Anttila <jussiva@gmail.com>)",
   "main": "lib/index",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "licenses" : "MIT",
   "dependencies": {
-    "mongoose": "3.8.1",
+    "mongoose": "^4.11.4",
     "flat": "*",
     "lodash": "*"
   },

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,18 +1,29 @@
 /* Node.js official modules */
-var fs = require('fs')
+const fs = require('fs')
 /* 3rd party modules */
   , mongoose = require('mongoose')
   , Schema = mongoose.Schema
-  , assert = require('chai').assert
-/* QueryPlugin itself */  
+  , type = require('type-detect')
+  , chai = require('chai')
+  , assert = chai.assert
+  , expect = chai.expect
+/* QueryPlugin itself */
   , Query = require('../');
-  
-var ObjectId = Schema.ObjectId;
-  
-var OrigSchema = new mongoose.Schema({
+
+mongoose.Promise = Promise;
+
+let isPromise = function (obj) {
+  return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
+}
+let assertPromise = function(obj) {
+  expect(isPromise(obj)).to.be.true;
+}
+
+const ObjectId = Schema.ObjectId;
+let OrigSchema = new mongoose.Schema({
   value: {type: String, default: 'original'}
 });
-var TestSchema = new mongoose.Schema({
+let TestSchema = new mongoose.Schema({
     title  : { type: String, index: true }
   , msg    : { type: String, lowercase: true, trim: true }
   , date   : {type: Date, default: Date.now}
@@ -24,106 +35,107 @@ var TestSchema = new mongoose.Schema({
   }
 });
 TestSchema.plugin(Query);
-var origModel = mongoose.model('originals', OrigSchema);
-var model = mongoose.model('test', TestSchema);
+const OrigTestModel = mongoose.model('originals', OrigSchema);
+const TestModel = mongoose.model('test', TestSchema);
+const docCount = 4000;
+const defaultLimit = 1000;
+let _id = '123123';
+
+let create = (i, max, callback) => {
+  if( i<max -1){
+    let obj = new TestModel({title: (i%2===0?'testa':'testb'), msg: 'i#'+i, orig: _id, i: i});
+    obj.save( (error, doc) => {
+      create(i+1, max, callback);
+    });
+  }
+  else {
+    let obj = new TestModel({_id: "57ae125aaf1b792c1768982b", title: (i%2===0?'testa':'testb'), msg: 'i#'+i, orig: _id, i: i});
+    obj.save( (error, doc) => {
+      callback();
+    });
+  }
+}
 
 
-mongoose.connect(  "mongodb://localhost/mongoose-query-tests", {} ); 
-var _id = '123123';
-var docCount = 4000;
-var defaultLimit = 1000;
 describe('Query:basic', function() {
   before( function(done){
-    this.timeout(10000);
-    
-    var create = function(i, max, callback){
-      if( i<max -1){
-        var obj = new model({title: (i%2===0?'testa':'testb'), msg: 'i#'+i, orig: _id, i: i});
-        obj.save( function(error, doc){
-          create(i+1, max, callback);
-        });
-      }
-      else {
-        var obj = new model({_id: "57ae125aaf1b792c1768982b", title: (i%2===0?'testa':'testb'), msg: 'i#'+i, orig: _id, i: i});
-        obj.save( function(error, doc){
-          callback();
-        });
-
-      }
-    }
-    mongoose.connection.on('connected', function(){
-      origModel.remove({}, function(){
-        var obj = new origModel();
-        obj.save( function(error, doc){
-           _id = doc._id;
-           model.remove({}, function(){
-            create(0, docCount, done);
-          });
-        });
-      });     
-    });
+    mongoose.connect(  "mongodb://localhost/mongoose-query-tests" );
+    mongoose.connection.on('connected', done);
   });
-  
+  before( function(done) {
+    OrigTestModel.remove({}, done);
+  });
+  before( function(done) {
+    this.timeout(10000);
+    let obj = new OrigTestModel();
+    obj.save( function(error, doc){
+       _id = doc._id;
+       TestModel.remove({}, function(){
+        create(0, docCount, done);
+      });
+    });
+  })
+
   it('all', function(done) {
     var req = {q:'{}'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal( error, undefined );
       assert.equal( data.length, defaultLimit );
       assert.isTrue( (data[0].orig+'').match(/([0-9a-z]{24})/) != null );
       //alternative:
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
   it('regex', function(done) {
     var req = {q:'{"title": {"$regex": "/^testa/"}, "i": { "$lt": 20}}'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal( error, undefined );
       assert.equal( data.length, 10 );
       assert.isTrue( (data[0].orig+'').match(/([0-9a-z]{24})/) != null );
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
   it('findOne & sort', function(done) {
     var req = {q:'{}', t: 'findOne', s: '{"msg": 1}'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal( error, undefined );
       assert.typeOf( data, 'Object' );
       assert.equal( data.title, 'testa' );
       assert.equal( data.msg, 'i#0' );
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Query);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
   it('exact', function(done) {
     var req = {q:'{"msg":"i#3"}'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal( error, undefined );
       assert.equal( data.length, 1 );
       assert.equal( data[0].msg, "i#3" );
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
   it('populate', function(done) {
     var req = {q:'{"msg":"i#3"}', p: 'orig'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal( error, undefined );
       assert.equal( data.length, 1 );
       assert.equal( data[0].msg, "i#3" );
       assert.equal( data[0].orig.value, "original" );
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
   it('limit & select', function(done) {
     var req = {q:'{}', f: 'title', l:'3', s: '{"title": -1}'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal( error, undefined );
       assert.equal( data.length, 3 );
       assert.equal( data[0].msg, undefined );
@@ -133,47 +145,47 @@ describe('Query:basic', function() {
       assert.equal( data[2].msg, undefined );
       assert.equal( data[2].title, "testb" );
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
-  
+
   it('skip', function(done) {
     var req = {q:'{}', sk:'3'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal( error, undefined );
       assert.equal( data.length, defaultLimit );
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
-  
+
   it('count', function(done) {
     var req = {q:'{"$or": [ {"msg":"i#1"}, {"msg":"i#2"}]}', t:'count'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal( error, undefined );
       assert.typeOf( data, 'object' );
       assert.equal( data.count, 2 );
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Query);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
-  
+
   it('distinct', function(done) {
     var req = {f:'title', t:'distinct'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal( error, undefined );
       assert.equal( data.length, 2 );
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Query);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
   it('flatten', function(done) {
     var req = {q:'{}', fl: 'true', l:'1'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal(error, undefined);
       assert.typeOf(data, 'array');
       data.forEach( function(item){
@@ -181,96 +193,96 @@ describe('Query:basic', function() {
         assert.equal(item['nest.ed'], 'value')
       });
       //this is not supported when no callback is used
-      assert.instanceOf(model.Query(req), Error);
+      assert.instanceOf(TestModel.query(req), Error);
       done();
     });
   });
   it('!empty', function(done){
     //Field exists and is not empty
     var req = {'nest.ed': '{!empty}-'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal(error, undefined);
       assert.equal(data[0].nest.ed, 'value');
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
   it('!empty', function(done){
-    //Field exists and is not empty 
+    //Field exists and is not empty
     var req = {'empty': '{!empty}-'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal(error, undefined);
       assert.equal(data.length, 0);
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
   it('empty', function(done){
     //Field is empty or not exists
     var req = {'empty': '{empty}-'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal(error, undefined);
       assert.equal(data.length, defaultLimit);
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
   it('limit more than default', function(done){
     //Field is empty or not exists
     var req = {'l': '2000'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal(error, undefined);
       assert.equal(data.length, 2000);
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
   it('limit with skip', function(done){
     //Field is empty or not exists
     var req = {'l': '2000', 'sk': '2500'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal(error, undefined);
       assert.equal(data.length, 1500);
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
   it('limit with filter', function(done){
     //Field is empty or not exists
     var req = {'l': '2000', 'q': '{ "title": "testa"}'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal(error, undefined);
       assert.equal(data.length, 2000);
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
   it('limit with sort', function(done){
     //Field is empty or not exists
     var req = {'l': '2000', 's': '{ "i": -1 }'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal(error, undefined);
       assert.equal(data.length, 2000);
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });
   it('oid wildcard', function(done) {
     var req = {q:'{"_id": "oid:57ae125aaf1b792c1768982b"}'};
-    model.Query(req, function(error, data){
+    TestModel.query(req, function(error, data){
       assert.equal( error, undefined );
       assert.equal( data.length, 1);
       assert.equal( data[0]._id, "57ae125aaf1b792c1768982b" );
 
       //alternative
-      assert.instanceOf(model.Query(req), mongoose.Promise);
+      assertPromise(TestModel.query(req));
       done();
     });
   });


### PR DESCRIPTION
* update mongoose dep to 4.11
* refactoring implementation
* add more query parser tests 
* several fixes.

**Note:** This drops `Model.Query` api. Please use `Model.query` instead.