### PR TITLE
Integrate forks changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,14 @@ Results with `fl=true`:
   'nest.ed.data2':'value'},
 ]
 ```
+
+
+#### Date
+
+Allowed date formats:
+- `2010/10/1` (y/m/d)
+- `31/2/2010` (d/m/y)
+- `2011-10-10T14:48:00` (ISO 8601)
+
+**Note:**
+Only valid format is ISO when using date inside `q` -parameter.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,12 @@ Alternative search conditions:
 "key={gt}a"                 Docs key is greater than a
 "key={lt}a"                 Docs key is lower than a
 "key=a|b|c"                 Docs where type of key is Array and contains at least one of given value
+"key={m}key,value"          elemMatch query
 ```
+
+**References to mongo:**
+- [elemMatch](https://docs.mongodb.com/manual/reference/operator/query/elemMatch/)
+- [size](https://docs.mongodb.com/manual/reference/operator/query/size/)
 
 Results with `fl=false`:
 ```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ schema.plugin( QueryPlugin(, <options>) )
 optional `options`:
 * `logger`: custom logger, e.g. winston logger, default: "dummy logger"
 * `allowEval`: <boolean> Allow to use eval or not, default: true
+* `includeAllParams`: <boolean> Parse also other values. e.g. `?name=me`. default: true
 
 Model static methods:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -145,6 +145,7 @@ module.exports = function QueryPlugin (schema, options) {
   let query = function (data, callback) {
     return doQuery.bind(this)(data, options, callback);
   };
+  schema.query.query = query;
   schema.static('query', query);
 
   let leanQuery = function (data, callback) {
@@ -152,5 +153,6 @@ module.exports = function QueryPlugin (schema, options) {
         _.defaults({lean: true}, options),
         callback);
   };
+  schema.query.leanQuery = leanQuery;
   schema.static('leanQuery', leanQuery);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,23 +13,23 @@ const flatten = require('flat').flatten
   , parseQuery = require('./parseQuery')
   , logger = require('./logger');
 
-module.exports = function QueryPlugin (schema, options) {
-
-  options = options || {};
+function QueryPlugin (schema, options = {}) {
+  _.defaults(options, {
+    allowEval: true
+  });
   if(_.has(options, 'logger')) {
     logger.setLogger(logger);
   }
-  let allowEval = _.get(options, 'allowEval', true);
   let doEval = (str) => {
-    if(allowEval) {
+    if(options.allowEval) {
       return eval(str);
     } else {
       return false;
     }
-  }
+  };
   options = _.omit(options, ['logger', 'allowEval', 'lean']);
 
-  let doQuery = function (data, opt, callback) {
+  const doQuery = function (data, opt, callback) {
     logger.debug('doQuery:', data, opt, callback);
     let q = parseQuery(data, opt);
     if(!this instanceof mongoose.Model) {
@@ -141,7 +141,7 @@ module.exports = function QueryPlugin (schema, options) {
         }
       }
     }
-  }
+  };
   let query = function (data, callback) {
     return doQuery.bind(this)(data, options, callback);
   };
@@ -156,3 +156,7 @@ module.exports = function QueryPlugin (schema, options) {
   schema.query.leanQuery = leanQuery;
   schema.static('leanQuery', leanQuery);
 }
+
+QueryPlugin.parseQuery = parseQuery;
+
+module.exports = QueryPlugin;

--- a/lib/parseQuery.js
+++ b/lib/parseQuery.js
@@ -6,7 +6,7 @@ const _ = require('lodash')
   , tools = require('./tools')
   , toBool = tools.toBool
   , toJSON = tools.toJSON
-  , isStringValidDate = tools.isStringValidDate;
+  , parseDateCustom = tools.parseDateCustom;
 
 module.exports = function parseQuery(query, options){
   /**
@@ -116,10 +116,11 @@ module.exports = function parseQuery(query, options){
           operator === "lte" ||
           operator === "ne" ||
           operator === "size") {
-            if (isStringValidDate(val)) {
-              val = new Date(val);
+            const date = parseDateCustom(val);
+            if (date !== NaN && operator !== "size") {
+              val = date;
             }
-            let tmp = {}
+            let tmp = {};
             let arrayOperators = ['in', 'nin', 'all', 'mod']
             if (_.indexOf(arrayOperators, operator)!==-1) {
               val = val.split(',');

--- a/lib/parseQuery.js
+++ b/lib/parseQuery.js
@@ -75,7 +75,7 @@ function parseQuery(query, options = {}){
     } else {
       qy.q[key] = val;
     }
-  }
+  };
 
   let parseParam = function(key, val){
     let lcKey = key;
@@ -85,6 +85,10 @@ function parseQuery(query, options = {}){
         if (operator){
           val = val.replace(/\{(.*)\}/, '');
           operator = operator[1];
+        }
+        const num = Number(val);
+        if(val !== '' && !isNaN(num)){
+            val = num;
         }
     }
     if (key[0] == '$' ) return; //bypass $ characters for security reasons!
@@ -165,16 +169,20 @@ function parseQuery(query, options = {}){
              (options.ignoreKeys.indexOf(key) !== -1))) {
               return;
           }
-          let parts = val.split('|');
-          if (parts.length > 1) {
-            for(i=0;i<parts.length;i++){
-              let tmp = {}
-              tmp[lcKey] = parts[i];
-              addCondition('$or', tmp);
+          if (_.isString(val)) {
+            let parts = val.split('|');
+            if (parts.length > 1) {
+              for(i=0;i<parts.length;i++){
+                let tmp = {}
+                tmp[lcKey] = parts[i];
+                addCondition('$or', tmp);
+              }
+            } else {
+              addCondition(lcKey, val );
             }
           } else {
-            addCondition(lcKey, val );
-          }
+              addCondition(lcKey, val );
+            }
         }
       }
     }

--- a/lib/parseQuery.js
+++ b/lib/parseQuery.js
@@ -116,12 +116,15 @@ module.exports = function parseQuery(query, options){
           operator === "lte" ||
           operator === "ne" ||
           operator === "size") {
+            const arrayOperators = ['in', 'nin', 'all', 'mod'];
             const date = parseDateCustom(val);
-            if (date !== NaN && operator !== "size") {
+            if (date !== NaN &&
+              operator !== "size" &&
+              !_.has(arrayOperators, operator)) {
               val = date;
             }
             let tmp = {};
-            let arrayOperators = ['in', 'nin', 'all', 'mod']
+
             if (_.indexOf(arrayOperators, operator)!==-1) {
               val = val.split(',');
             }

--- a/lib/parseQuery.js
+++ b/lib/parseQuery.js
@@ -141,11 +141,15 @@ function parseQuery(query, options = {}){
           addCondition(lcKey, new RegExp('^' + val));
         } else if (operator == 'm') {
           // key={m}<key>,<value>
-          let value = val.split(',');
-          qy.q[key] = {};
-          qy.q[key]['$elemMatch']  = {};
-          qy.q[key]['$elemMatch']['key']  = value[0];
-          qy.q[key]['$elemMatch']['value']  = value[1];
+          // key={m}<value>
+          if (_.isString(val)) {
+            const match = val.match(/(.*),(.*)/);
+            if (match) {
+              qy.q[key] = {};
+              qy.q[key]['$elemMatch'] = {};
+              qy.q[key]['$elemMatch'][match[1]] = match[2];
+            }
+          }
         } else if (operator == 'empty') {
           let empty = {};
           empty[lcKey] = '';

--- a/lib/parseQuery.js
+++ b/lib/parseQuery.js
@@ -120,7 +120,7 @@ module.exports = function parseQuery(query, options){
             const date = parseDateCustom(val);
             if (date !== NaN &&
               operator !== "size" &&
-              !_.has(arrayOperators, operator)) {
+              !_.indexOf(arrayOperators, operator) === -1) {
               val = date;
             }
             let tmp = {};

--- a/lib/parseQuery.js
+++ b/lib/parseQuery.js
@@ -8,7 +8,7 @@ const _ = require('lodash')
   , toJSON = tools.toJSON
   , parseDateCustom = tools.parseDateCustom;
 
-module.exports = function parseQuery(query, options){
+function parseQuery(query, options = {}){
   /**
 
   reserved keys: q,t,f,s,sk,l,p
@@ -50,8 +50,7 @@ module.exports = function parseQuery(query, options){
   "key=a|b|c"
   "Docs where key type is Array, contains at least one of given value
   */
-
-  options = options || {};
+  _.defaults(options, {includeAllParams: true});
 
   let qy = {
     q: {},        //  query
@@ -236,9 +235,11 @@ module.exports = function parseQuery(query, options){
       case('reduce'): qy.reduce = query[key]; break;
       case('fl'): qy.fl = toBool(query[key]); break;
       default:
-        parseParam(key, query[key]);
+        if (options.includeAllParams) parseParam(key, query[key]);
         break;
     }
   }
   return qy;
 }
+
+module.exports = parseQuery;

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -14,6 +14,8 @@ module.exports.toJSON = function(str){
 module.exports.toBool = function (str) {
   if (_.isUndefined(str))
     return true;
+  if (!_.isString(str))
+    return -1;
   if (str.toLowerCase() === "true" ||
       str.toLowerCase() === "yes" ){
     return true;

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -43,8 +43,10 @@ function isDate(val) {
   return util.isDate(val) && !isNaN(val.getTime());
 }
 module.exports.isStringValidDate = function(str){
-  if(isDate(new Date(str)))return true;
-  if(isDate(parseDate(str)))return true;
-  if(isDate(parseDate2(str)))return true;
+  if (!_.isString(str)) return false;
+  if (str.match(/^[\d\.\,]{1,}$/)) return false;
+  if (isDate(new Date(str))) return true;
+  if (isDate(parseDate(str))) return true;
+  if (isDate(parseDate2(str))) return true;
   return false;
 };

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,9 +1,8 @@
-const util = require('util')
-  , _ = require('lodash')
-  , logger = require('./logger');
+const _ = require('lodash');
+const logger = require('./logger');
 
 module.exports.toJSON = function(str){
-  var json = {}
+  let json = {};
   try{
     json = JSON.parse(str);
   } catch(e){
@@ -15,9 +14,6 @@ module.exports.toJSON = function(str){
 module.exports.toBool = function (str) {
   if (_.isUndefined(str))
     return true;
-  if (_.isNumber(str)) {
-    return str === 0 ? false : true;
-  }
   if (str.toLowerCase() === "true" ||
       str.toLowerCase() === "yes" ){
     return true;
@@ -29,24 +25,46 @@ module.exports.toBool = function (str) {
     return -1;
   }
 };
-function parseDate(str) {
+
+
+function parseDateFormat1(str) {
   //31/2/2010
-  var m = str.match(/^(\d{1,2})[\/\s\.\-\,](\d{1,2})[\/\s\.\-\,](\d{4})$/);
-  return (m) ? new Date(m[3], m[2]-1, m[1]) : null;
+  const m = str.match(/^(\d{1,2})[\/\s\.\-\,](\d{1,2})[\/\s\.\-\,](\d{4})$/);
+  return (m) ? new Date(m[3], m[2]-1, m[1]) : NaN;
 }
-function parseDate2(str) {
+function parseDateFormat2(str) {
   //2010/31/2
-  var m = str.match(/^(\d{4})[\/\s\.\-\,](\d{1,2})[\/\s\.\-\,](\d{1,2})$/);
-  return (m) ? new Date(m[1], m[2]-1, m[3]) : null;
+  const m = str.match(/^(\d{4})[\/\s\.\-\,](\d{1,2})[\/\s\.\-\,](\d{1,2})$/);
+  return (m) ? new Date(m[1], m[2]-1, m[3]) : NaN;
+}
+
+function containsInvalidDateStr(str) {
+  if (!_.isString(str)) return true;
+  if (str.match(/[\d]/) === null) return true; // no any numbers
+  if (str.match(/.*[-:T\/].*/) === null) return true; // no any date parts related characters
+  return false;
+}
+function newDate(str) {
+  return new Date(str);
 }
 function isDate(val) {
-  return util.isDate(val) && !isNaN(val.getTime());
+  return _.isDate(val) && !isNaN(val.getTime());
 }
-module.exports.isStringValidDate = function(str){
-  if (!_.isString(str)) return false;
-  if (str.match(/^[\d\.\,]{1,}$/)) return false;
-  if (isDate(new Date(str))) return true;
-  if (isDate(parseDate(str))) return true;
-  if (isDate(parseDate2(str))) return true;
-  return false;
+
+/**
+ * Custom date parser - because there is no indicate when string is used as a int and when as a date.
+ * e.g. 2010 -> assuming it's number
+ * 2010/10/1 -> its'a date (y/m/d) but Date.parse doesn't detect it
+ * //31/2/2010 -> it's another representation about date (m/d/y)
+ * @param {String}str
+ * @return {Date|NaN}
+ */
+module.exports.parseDateCustom = function(str){
+  if (containsInvalidDateStr(str)) return NaN;
+  let converters = [newDate, parseDateFormat1, parseDateFormat2];
+  for(let i in converters) {
+    let date = converters[i](str);
+    if(isDate(date)) return date;
+  }
+  return NaN;
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -33,6 +33,9 @@ let TestSchema = new mongoose.Schema({
   , empty  : {type: String}
   , orig   : {type: ObjectId, ref: 'originals' }
   , i      : {type: Number, index: true }
+  , arr    : [
+      {ay: {type: String}}
+    ]
   , nest   : {
     ed: {type: String, default: 'value'}
   }
@@ -47,7 +50,7 @@ let _id;
 
 let create = (i, max, callback) => {
   if( i<max -1){
-    let obj = new TestModel({title: (i%2===0?'testa':'testb'), msg: 'i#'+i, orig: _id, i: i});
+    let obj = new TestModel({title: (i%2===0?'testa':'testb'), msg: 'i#'+i, orig: _id, i: i, arr: [{ay: `i#${i}`}]});
     obj.save( (error, doc) => {
       create(i+1, max, callback);
     });
@@ -463,11 +466,20 @@ describe('Query:basic', function() {
     });
   });
   it('number search', function (done) {
-    const req = {i: 1};
+    const req = {i: '1'};
     TestModel.leanQuery(req, function(error, data) {
       assert.equal( error, undefined );
       assert.equal( data.length, 1);
       assert.equal( data[0].i, 1);
+      done();
+    });
+  });
+  it('match', function (done) {
+    const req = {arr: "{m}ay,i#1"};
+    TestModel.leanQuery(req, function(error, data) {
+      assert.equal(error, undefined );
+      assert.equal(data.length, 1);
+      assert.equal(data[0].arr[0].ay, 'i#1');
       done();
     });
   })

--- a/test/tests.js
+++ b/test/tests.js
@@ -462,4 +462,13 @@ describe('Query:basic', function() {
       promise.then(validateData).then(done);
     });
   });
+  it('number search', function (done) {
+    const req = {i: 1};
+    TestModel.leanQuery(req, function(error, data) {
+      assert.equal( error, undefined );
+      assert.equal( data.length, 1);
+      assert.equal( data[0].i, 1);
+      done();
+    });
+  })
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -11,7 +11,7 @@ const fs = require('fs')
 /* QueryPlugin itself */
   , Query = require('../')
   , parseQuery = require('../lib/parseQuery')
-  , {isStringValidDate} = require('../lib/tools');
+  , {parseDateCustom} = require('../lib/tools');
 
 mongoose.Promise = Promise;
 
@@ -61,15 +61,19 @@ let create = (i, max, callback) => {
 };
 
 describe('unittests', function() {
-  describe('isStringValidDate', function () {
-    it('is not valid', function () {
-      assert.isFalse(isStringValidDate("123456"));
-      assert.isFalse(isStringValidDate(""));
-      assert.isFalse(isStringValidDate());
+  describe('parseDateCustom', function () {
+    it('is not valid date', function () {
+      assert.isNaN(parseDateCustom("2000"));
+      assert.isNaN(parseDateCustom("1000128123"));
+      assert.isNaN(parseDateCustom("2011A1020"));
+      assert.isNaN(parseDateCustom(""));
+      assert.isNaN(parseDateCustom());
     });
     it('is valid', function () {
-      assert.isTrue(isStringValidDate("2017/09/10"));
-      assert.isTrue(isStringValidDate("31/2/2010"));
+      assert.isTrue(_.isDate(parseDateCustom("2017/09/10")));
+      assert.isTrue(_.isDate(parseDateCustom("31/2/2010")));
+      assert.isTrue(_.isDate(parseDateCustom("2011-10-10T14:48:00"))); // ISO 8601 with time
+      assert.isTrue(_.isDate(parseDateCustom("2011-10-10"))); // ISO 8601
     });
   });
   it('parseQuery', function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -114,7 +114,7 @@ describe('unittests', function() {
      assert.deepEqual(parseQuery({a: '{in}a,b'}),
                   _.defaults({q: {a: {$in: ['a','b']}}}, defaultResp));
      assert.deepEqual(parseQuery({a: '{m}k,v'}),
-                 _.defaults({q: {a: {$elemMatch: {key: 'k', value: 'v'}}}}, defaultResp));
+                 _.defaults({q: {a: {$elemMatch: {k: 'v'}}}}, defaultResp));
      assert.deepEqual(parseQuery({a: '{empty}'}),
                  _.defaults({q: {$or: [{a: ''}, {a: {$exists: false}}]}}, defaultResp));
      assert.deepEqual(parseQuery({a: '{!empty}'}),

--- a/test/tests.js
+++ b/test/tests.js
@@ -10,7 +10,8 @@ const fs = require('fs')
   , expect = chai.expect
 /* QueryPlugin itself */
   , Query = require('../')
-  , parseQuery = require('../lib/parseQuery');
+  , parseQuery = require('../lib/parseQuery')
+  , {isStringValidDate} = require('../lib/tools');
 
 mongoose.Promise = Promise;
 
@@ -59,31 +60,17 @@ let create = (i, max, callback) => {
   }
 };
 
-
-describe('Query:basic', function() {
-  before(function(done){
-    const useMongoClient = true;
-    mongoose.connect("mongodb://localhost/mongoose-query-tests", {useMongoClient});
-    mongoose.connection.on('connected', done);
-  });
-  before(function(done) {
-    this.timeout(10000);
-    let obj = new OrigTestModel();
-    obj.save((error, doc) => {
-       _id = doc._id;
-       TestModel.remove({}, () => {
-        create(0, docCount, done);
-      });
+describe('unittests', function() {
+  describe('isStringValidDate', function () {
+    it('is not valid', function () {
+      assert.isFalse(isStringValidDate("123456"));
+      assert.isFalse(isStringValidDate(""));
+      assert.isFalse(isStringValidDate());
     });
-  });
-  after(function(done) {
-    OrigTestModel.remove({}, done);
-  });
-  after(function(done) {
-    TestModel.remove({}, done);
-  });
-  after(function(done) {
-    mongoose.disconnect(done);
+    it('is valid', function () {
+      assert.isTrue(isStringValidDate("2017/09/10"));
+      assert.isTrue(isStringValidDate("31/2/2010"));
+    });
   });
   it('parseQuery', function() {
     let defaultResp = {
@@ -129,6 +116,33 @@ describe('Query:basic', function() {
                  _.defaults({q: {$or: [{a: 'b'}, {a: 'c'}, {a: 'd'}]}}, defaultResp));
 
   });
+});
+describe('Query:basic', function() {
+  before(function(done){
+    const useMongoClient = true;
+    mongoose.connect("mongodb://localhost/mongoose-query-tests", {useMongoClient});
+    mongoose.connection.on('connected', done);
+  });
+  before(function(done) {
+    this.timeout(10000);
+    let obj = new OrigTestModel();
+    obj.save((error, doc) => {
+       _id = doc._id;
+       TestModel.remove({}, () => {
+        create(0, docCount, done);
+      });
+    });
+  });
+  after(function(done) {
+    OrigTestModel.remove({}, done);
+  });
+  after(function(done) {
+    TestModel.remove({}, done);
+  });
+  after(function(done) {
+    mongoose.disconnect(done);
+  });
+
   it('find', function(done) {
     const req = {q:'{}'};
     TestModel.query(req, function(error, data){


### PR DESCRIPTION
* includeAllParams -option (activated by default)
* exports parseQuery
* update documentation
* Attach a query method to a schema's [query property](http://thecodebarbarian.com/mongoose-custom-query-methods) 
* fix: `key=<number>` number search 
* fix: `{m}` -query (elemMatch)