### PR TITLE
Some strings are detected as date, but they should not

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -62,7 +62,6 @@ function getMomentAllowedFormats() {
 
   const delimiters = ['.', '/', '-'];
 
-
   for (let i = 0; i < delimiters.length; i += 1) {
     for (let j = 0; j < defaultFormats.length; j += 1) {
       formats.push(defaultFormats[j].replace(/\|/g, delimiters[i]));

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,14 +1,19 @@
 const _ = require('lodash');
+const moment = require('moment');
 
 module.exports.toBool = function toBool(str) {
-  if (_.isUndefined(str)) { return true; }
-  if (!_.isString(str)) { return -1; }
+  if (_.isUndefined(str)) {
+    return true;
+  }
+  if (!_.isString(str)) {
+    return -1;
+  }
   if (str.toLowerCase() === 'true' ||
-      str.toLowerCase() === 'yes') {
+        str.toLowerCase() === 'yes') {
     return true;
   } else if (
     str.toLowerCase() === 'false' ||
-      str.toLowerCase() === 'no') {
+        str.toLowerCase() === 'no') {
     return false;
   }
   return -1;
@@ -36,21 +41,56 @@ function parseDateFormat1(str) {
   const m = str.match(/^(\d{1,2})[/\s.\-,](\d{1,2})[/\s.\-,](\d{4})$/);
   return (m) ? new Date(m[3], m[2] - 1, m[1]) : NaN;
 }
+
 function parseDateFormat2(str) {
   // 2010/31/2
   const m = str.match(/^(\d{4})[/\s.\-,](\d{1,2})[/\s.\-,](\d{1,2})$/);
   return (m) ? new Date(m[1], m[2] - 1, m[3]) : NaN;
 }
 
+
+function getMomentAllowedFormats() {
+  const formats = [];
+
+  const defaultFormats = [
+    'DD|MM|YYYY HH:mm', 'MM|DD|YYYY HH:mm', 'MM|DD|YYYY', 'DD|MM|YYYY', 'YYYY|MM|DD', 'YYYY|DD|MM',
+    'DD|M|YYYY HH:mm', 'M|DD|YYYY HH:mm', 'M|DD|YYYY', 'DD|M|YYYY', 'YYYY|M|DD', 'YYYY|DD|M',
+    'D|MM|YYYY HH:mm', 'MM|D|YYYY HH:mm', 'MM|D|YYYY', 'D|MM|YYYY', 'YYYY|MM|D', 'YYYY|D|MM',
+    'D|M|YYYY HH:mm', 'M|D|YYYY HH:mm', 'M|D|YYYY', 'D|M|YYYY', 'YYYY|M|D', 'YYYY|D|M',
+    'YYYY|MM|DDTHH:mm:ss', 'YYYY|DD|MMTHH:mm:ss'
+  ];
+
+  const delimiters = ['.', '/', '-'];
+
+
+  for (let i = 0; i < delimiters.length; i += 1) {
+    for (let j = 0; j < defaultFormats.length; j += 1) {
+      formats.push(defaultFormats[j].replace(/\|/g, delimiters[i]));
+    }
+  }
+
+  return formats;
+}
+
 function containsInvalidDateStr(str) {
   if (!_.isString(str)) return true;
   if (str.match(/[\d]/) === null) return true; // no any numbers
   if (str.match(/.*[-:T/].*/) === null) return true; // no any date parts related characters
+  const rfc2822Moment = moment(str, moment.RFC_2822, true);
+  const isoMoment = moment(str, moment.ISO_8601, true);
+  const allOthersMoment = moment(str, getMomentAllowedFormats(), true);
+  const rfc2822 = rfc2822Moment.isValid();
+  const iso = isoMoment.isValid();
+  const allOthers = allOthersMoment.isValid();
+
+  if (!rfc2822 && !iso && !allOthers) return true;
   return false;
 }
+
 function newDate(str) {
   return new Date(str);
 }
+
 function isDate(val) {
   return _.isDate(val) && !Number.isNaN(val.getTime());
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "flat": "*",
     "lodash": "*",
+    "moment": "^2.22.1",
     "mongoose": "^5.0.8"
   },
   "devDependencies": {

--- a/test/tests.js
+++ b/test/tests.js
@@ -53,10 +53,11 @@ describe('unittests', function () {
       assert.isNaN(parseDateCustom('2011A1020'));
       assert.isNaN(parseDateCustom(''));
       assert.isNaN(parseDateCustom());
+      assert.isNaN(parseDateCustom('test-yannick-2'));
     });
     it('is valid', function () {
       assert.isTrue(_.isDate(parseDateCustom('2017/09/10')));
-      assert.isTrue(_.isDate(parseDateCustom('31/2/2010')));
+      assert.isTrue(_.isDate(parseDateCustom('31/3/2010')));
       assert.isTrue(_.isDate(parseDateCustom('2011-10-10T14:48:00'))); // ISO 8601 with time
       assert.isTrue(_.isDate(parseDateCustom('2011-10-10'))); // ISO 8601
     });


### PR DESCRIPTION
We use in our project this library and we had a case where the string 'test-yannick-2' was interpreted as a date. This should not happen. We provided a quick solution for our problem with moment.js. Please review the chanes and maybe accept the pull request or consider to write a own solution for these problems.

