### PR TITLE
Some strings are detected as date, but they should not

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -49,9 +49,10 @@ function parseDateFormat2(str) {
 }
 
 
+const TOSTRING_FORMAT = 'ddd MMM D YYYY HH:mm:ss [GMT]ZZ';
+
 function getMomentAllowedFormats() {
   const formats = [];
-
   const defaultFormats = [
     'DD|MM|YYYY HH:mm', 'MM|DD|YYYY HH:mm', 'MM|DD|YYYY', 'DD|MM|YYYY', 'YYYY|MM|DD', 'YYYY|DD|MM',
     'DD|M|YYYY HH:mm', 'M|DD|YYYY HH:mm', 'M|DD|YYYY', 'DD|M|YYYY', 'YYYY|M|DD', 'YYYY|DD|M',
@@ -77,12 +78,15 @@ function containsInvalidDateStr(str) {
   if (str.match(/.*[-:T/].*/) === null) return true; // no any date parts related characters
   const rfc2822Moment = moment(str, moment.RFC_2822, true);
   const isoMoment = moment(str, moment.ISO_8601, true);
-  const allOthersMoment = moment(str, getMomentAllowedFormats(), true);
+  const momentAllowedFormats = getMomentAllowedFormats();
+  const strFormat = moment(str, TOSTRING_FORMAT);
+  const allOthersMoment = moment(str, momentAllowedFormats, true);
   const rfc2822 = rfc2822Moment.isValid();
   const iso = isoMoment.isValid();
+  const strValid = strFormat.isValid();
   const allOthers = allOthersMoment.isValid();
 
-  if (!rfc2822 && !iso && !allOthers) return true;
+  if (!rfc2822 && !iso && !allOthers && !strValid) return true;
   return false;
 }
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -62,7 +62,6 @@ function getMomentAllowedFormats() {
 
   const delimiters = ['.', '/', '-'];
 
-
   for (let i = 0; i < delimiters.length; i += 1) {
     for (let j = 0; j < defaultFormats.length; j += 1) {
       formats.push(defaultFormats[j].replace(/\|/g, delimiters[i]));

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,14 +1,19 @@
 const _ = require('lodash');
+const moment = require('moment');
 
 module.exports.toBool = function toBool(str) {
-  if (_.isUndefined(str)) { return true; }
-  if (!_.isString(str)) { return -1; }
+  if (_.isUndefined(str)) {
+    return true;
+  }
+  if (!_.isString(str)) {
+    return -1;
+  }
   if (str.toLowerCase() === 'true' ||
-      str.toLowerCase() === 'yes') {
+        str.toLowerCase() === 'yes') {
     return true;
   } else if (
     str.toLowerCase() === 'false' ||
-      str.toLowerCase() === 'no') {
+        str.toLowerCase() === 'no') {
     return false;
   }
   return -1;
@@ -36,21 +41,56 @@ function parseDateFormat1(str) {
   const m = str.match(/^(\d{1,2})[/\s.\-,](\d{1,2})[/\s.\-,](\d{4})$/);
   return (m) ? new Date(m[3], m[2] - 1, m[1]) : NaN;
 }
+
 function parseDateFormat2(str) {
   // 2010/31/2
   const m = str.match(/^(\d{4})[/\s.\-,](\d{1,2})[/\s.\-,](\d{1,2})$/);
   return (m) ? new Date(m[1], m[2] - 1, m[3]) : NaN;
 }
 
+
+function getMomentAllowedFormats() {
+  const formats = [];
+
+  const defaultFormats = [
+    'DD|MM|YYYY HH:mm', 'MM|DD|YYYY HH:mm', 'MM|DD|YYYY', 'DD|MM|YYYY', 'YYYY|MM|DD', 'YYYY|DD|MM',
+    'DD|M|YYYY HH:mm', 'M|DD|YYYY HH:mm', 'M|DD|YYYY', 'DD|M|YYYY', 'YYYY|M|DD', 'YYYY|DD|M',
+    'D|MM|YYYY HH:mm', 'MM|D|YYYY HH:mm', 'MM|D|YYYY', 'D|MM|YYYY', 'YYYY|MM|D', 'YYYY|D|MM',
+    'D|M|YYYY HH:mm', 'M|D|YYYY HH:mm', 'M|D|YYYY', 'D|M|YYYY', 'YYYY|M|D', 'YYYY|D|M',
+    'YYYY|MM|DDTHH:mm:ss', 'YYYY|DD|MMTHH:mm:ss'
+  ];
+
+  const delimiters = ['.', '/', '-'];
+
+
+  for (let i = 0; i < delimiters.length; i += 1) {
+    for (let j = 0; j < defaultFormats.length; j += 1) {
+      formats.push(defaultFormats[j].replace(/\|/g, delimiters[i]));
+    }
+  }
+
+  return formats;
+}
+
 function containsInvalidDateStr(str) {
   if (!_.isString(str)) return true;
   if (str.match(/[\d]/) === null) return true; // no any numbers
   if (str.match(/.*[-:T/].*/) === null) return true; // no any date parts related characters
+  const rfc2822Moment = moment(str, moment.RFC_2822, true);
+  const isoMoment = moment(str, moment.ISO_8601, true);
+  const allOthersMoment = moment(str, getMomentAllowedFormats(), true);
+  const rfc2822 = rfc2822Moment.isValid();
+  const iso = isoMoment.isValid();
+  const allOthers = allOthersMoment.isValid();
+
+  if (!rfc2822 && !iso && !allOthers) return true;
   return false;
 }
+
 function newDate(str) {
   return new Date(str);
 }
+
 function isDate(val) {
   return _.isDate(val) && !Number.isNaN(val.getTime());
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "flat": "*",
     "lodash": "*",
+    "moment": "^2.22.1",
     "mongoose": "^5.0.8"
   },
   "devDependencies": {

--- a/test/tests.js
+++ b/test/tests.js
@@ -230,8 +230,7 @@ describe('Query:apitests', function () {
   };
 
   before(function (done) {
-    const useMongoClient = true;
-    mongoose.connect('mongodb://localhost/mongoose-query-tests', { useMongoClient });
+    mongoose.connect('mongodb://localhost/mongoose-query-tests');
     mongoose.connection.on('connected', done);
   });
   before(function (done) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -53,10 +53,11 @@ describe('unittests', function () {
       assert.isNaN(parseDateCustom('2011A1020'));
       assert.isNaN(parseDateCustom(''));
       assert.isNaN(parseDateCustom());
+      assert.isNaN(parseDateCustom('test-yannick-2'));
     });
     it('is valid', function () {
       assert.isTrue(_.isDate(parseDateCustom('2017/09/10')));
-      assert.isTrue(_.isDate(parseDateCustom('31/2/2010')));
+      assert.isTrue(_.isDate(parseDateCustom('31/3/2010')));
       assert.isTrue(_.isDate(parseDateCustom('2011-10-10T14:48:00'))); // ISO 8601 with time
       assert.isTrue(_.isDate(parseDateCustom('2011-10-10'))); // ISO 8601
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -54,12 +54,14 @@ describe('unittests', function () {
       assert.isNaN(parseDateCustom(''));
       assert.isNaN(parseDateCustom());
       assert.isNaN(parseDateCustom('test-yannick-2'));
+      assert.isNaN(parseDateCustom('Thue May 15 2018 23:15:16 GMT+0300 (EEST)'));
     });
     it('is valid', function () {
       assert.isTrue(_.isDate(parseDateCustom('2017/09/10')));
       assert.isTrue(_.isDate(parseDateCustom('31/3/2010')));
       assert.isTrue(_.isDate(parseDateCustom('2011-10-10T14:48:00'))); // ISO 8601 with time
       assert.isTrue(_.isDate(parseDateCustom('2011-10-10'))); // ISO 8601
+      assert.isTrue(_.isDate(parseDateCustom('Tue May 15 2018 23:15:16 GMT+0300 (EEST)'))); // Date.toString() -fmt
     });
   });
   describe('parseQuery', function () {


### PR DESCRIPTION
## Status
**READY**

## Description
Date parser did not work properly e.g. in case of `'test-yannick-2'`. This PR will improve date parsing by being more strict.

## Related PR:
Originally raised here: #41 
