### PR TITLE
parse values properly from q or from plain parameter.

### DIFF
--- a/lib/parseQuery.js
+++ b/lib/parseQuery.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-
+const {Types} = require('mongoose');
 // module tools
 const tools = require('./tools');
 
@@ -253,7 +253,8 @@ function parseQuery(query, options = {}) {
         }
       } else if (/^oid:[a-fA-F0-9]{24}$/.test(value)) {
         // eslint-disable-next-line no-param-reassign, prefer-destructuring
-        obj[key] = value.split(':')[1];
+        const objId = value.split(':')[1];
+        obj[key] = new Types.ObjectId(objId);
       } else {
         // check if date to convert it
         const date = parseDateCustom(value);
@@ -315,7 +316,9 @@ function parseQuery(query, options = {}) {
     } else if (key === 'fl') {
       qy.fl = toBool(value);
     } else if (options.includeAllParams) {
-      parseParam(key, value);
+      const obj = {};
+      jsonConverter(value, key, obj);
+      parseParam(key, obj[key]);
     }
   }
   return qy;

--- a/lib/parseQuery.js
+++ b/lib/parseQuery.js
@@ -261,6 +261,8 @@ function parseQuery(query, options = {}) {
         if (!Number.isNaN(date)) {
           // eslint-disable-next-line no-param-reassign
           obj[key] = date;
+        } else {
+          obj[key] = value;
         }
       }
     }

--- a/lib/parseQuery.js
+++ b/lib/parseQuery.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const {Types} = require('mongoose');
+const { Types } = require('mongoose');
 // module tools
 const tools = require('./tools');
 
@@ -252,8 +252,9 @@ function parseQuery(query, options = {}) {
           obj[key] = new RegExp(m[1], m[2]);
         }
       } else if (/^oid:[a-fA-F0-9]{24}$/.test(value)) {
-        // eslint-disable-next-line no-param-reassign, prefer-destructuring
+        // eslint-disable-next-line prefer-destructuring
         const objId = value.split(':')[1];
+        // eslint-disable-next-line no-param-reassign
         obj[key] = new Types.ObjectId(objId);
       } else {
         // check if date to convert it
@@ -262,6 +263,7 @@ function parseQuery(query, options = {}) {
           // eslint-disable-next-line no-param-reassign
           obj[key] = date;
         } else {
+          // eslint-disable-next-line no-param-reassign
           obj[key] = value;
         }
       }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "flat": "*",
-    "lodash": ">=4.17.9",
-    "moment": "^2.22.1",
+    "flat": "^4.1.0",
+    "lodash": "^4.17.11",
+    "moment": "^2.24.0",
     "mongoose": "^5.5.12"
   },
   "devDependencies": {

--- a/test/tests.js
+++ b/test/tests.js
@@ -86,6 +86,19 @@ describe('unittests', function () {
         mergeResult({ q: { fieldName: new Types.ObjectId('000000000000000000000000') } })
       );
     });
+    it('objectid is parsed correctly from $match', function () {
+      assert.deepEqual(
+        parseQuery({ q: JSON.stringify({ $match: { fieldName: 'oid:000000000000000000000000' } }) }),
+        mergeResult({
+          q: {
+            $match: {
+              fieldName: new Types.ObjectId('000000000000000000000000')
+            }
+          }
+        })
+      );
+    });
+
     it('objectid is parsed correctly from parameter', function () {
       assert.deepEqual(
         parseQuery({ fieldName: 'oid:000000000000000000000000' }),

--- a/test/tests.js
+++ b/test/tests.js
@@ -80,16 +80,16 @@ describe('unittests', function () {
     };
     const mergeResult = obj => _.merge({}, defaultResp, obj);
 
-    it('objectid is parsed correctly from q', function () {
+    it('objectid is parsed correctly from q', function () {
       assert.deepEqual(
-          parseQuery({q: JSON.stringify({"fieldName":"oid:000000000000000000000000"})}),
-          mergeResult({q: {fieldName: new Types.ObjectId('000000000000000000000000')}})
+        parseQuery({ q: JSON.stringify({ fieldName: 'oid:000000000000000000000000' }) }),
+        mergeResult({ q: { fieldName: new Types.ObjectId('000000000000000000000000') } })
       );
     });
-    it('objectid is parsed correctly from parameter', function () {
+    it('objectid is parsed correctly from parameter', function () {
       assert.deepEqual(
-          parseQuery({"fieldName":"oid:000000000000000000000000"}),
-          mergeResult({q: {fieldName: new Types.ObjectId('000000000000000000000000')}})
+        parseQuery({ fieldName: 'oid:000000000000000000000000' }),
+        mergeResult({ q: { fieldName: new Types.ObjectId('000000000000000000000000') } })
       );
     });
     it('option q(query as a json) is parsed correctly', function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const mongoose = require('mongoose');
 const chai = require('chai');
 
-const { Schema } = mongoose;
+const { Schema, Types } = mongoose;
 const { assert, expect } = chai;
 
 /* QueryPlugin itself */
@@ -80,14 +80,25 @@ describe('unittests', function () {
     };
     const mergeResult = obj => _.merge({}, defaultResp, obj);
 
-
+    it('objectid is parsed correctly from q', function () {
+      assert.deepEqual(
+          parseQuery({q: JSON.stringify({"fieldName":"oid:000000000000000000000000"})}),
+          mergeResult({q: {fieldName: new Types.ObjectId('000000000000000000000000')}})
+      );
+    });
+    it('objectid is parsed correctly from parameter', function () {
+      assert.deepEqual(
+          parseQuery({"fieldName":"oid:000000000000000000000000"}),
+          mergeResult({q: {fieldName: new Types.ObjectId('000000000000000000000000')}})
+      );
+    });
     it('option q(query as a json) is parsed correctly', function () {
       const date = new Date();
       assert.deepEqual(
         parseQuery({ q: `{"a": "b", "b": 1, "c": "${date.toISOString()}", "d": "oid:000000000000000000000000"}` }),
         mergeResult({
           q: {
-            a: 'b', b: 1, c: date, d: '000000000000000000000000'
+            a: 'b', b: 1, c: date, d: new Types.ObjectId('000000000000000000000000')
           }
         })
       );


### PR DESCRIPTION
* convert `oid:XXX` -string value  to `ObjectId`
* Convert values from parameter properly, e.g. `?_id=oid:XXXX` or  `?time=2011-10-10`

Fixes #79