### PR TITLE
Update parseQuery.js

### DIFF
--- a/lib/parseQuery.js
+++ b/lib/parseQuery.js
@@ -251,6 +251,8 @@ function parseQuery(query, options = {}) {
           // eslint-disable-next-line no-param-reassign
           obj[key] = new RegExp(m[1], m[2]);
         }
+      } else if(key === '$search') { // handle special case text search
+        obj[key] = value;
       } else if (/^oid:[a-fA-F0-9]{24}$/.test(value)) {
         // eslint-disable-next-line prefer-destructuring
         const objId = value.split(':')[1];

--- a/test/tests.js
+++ b/test/tests.js
@@ -80,6 +80,13 @@ describe('unittests', function () {
     };
     const mergeResult = obj => _.merge({}, defaultResp, obj);
 
+    it('text search is parsed correctly from q', function () {
+      assert.deepEqual(
+        parseQuery({ q: JSON.stringify({ $text: {$search: '100-10-7' }}) }),
+        mergeResult({ q: { $text: {$search: '100-10-7' }} })
+      );
+    });
+
     it('objectid is parsed correctly from q', function () {
       assert.deepEqual(
         parseQuery({ q: JSON.stringify({ fieldName: 'oid:000000000000000000000000' }) }),


### PR DESCRIPTION
add handling of textIndex / search for a phrase, which could be wrongly detected as a date